### PR TITLE
fix(settings): Highlight i18n locale if preference is not valid

### DIFF
--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -14,6 +14,7 @@
               <settings-options
                 :settings-key="['lang']"
                 :values="{'en': 'en', 'hu': 'hu'}"
+                :custom-value="$store.state.settings.lang ? $store.state.settings.lang : $i18n.locale"
               />
               <divider />
               <settings-check :settings-key="['adaptiveTicking', 'enabled']" />


### PR DESCRIPTION
If the settings store does not have a selected locale, the language selector will use the i18n module's locale.

Closes #54