### PR TITLE
refactor: Fix `vue/component-tag-order` warnings

### DIFF
--- a/components/base/button.vue
+++ b/components/base/button.vue
@@ -16,6 +16,30 @@
   </Component>
 </template>
 
+<script>
+export default {
+  name: 'ControlButton',
+  props: {
+    tag: {
+      default: 'button',
+      type: String
+    },
+    disabled: {
+      default: false,
+      type: Boolean
+    },
+    subtle: {
+      default: false,
+      type: Boolean
+    },
+    noStyle: {
+      default: false,
+      type: Boolean
+    }
+  }
+}
+</script>
+
 <style lang="scss" scoped>
 .ui-button {
   transition: background-color 0.1s ease-out;
@@ -54,27 +78,3 @@
   opacity: 0.5;
 }
 </style>
-
-<script>
-export default {
-  name: 'ControlButton',
-  props: {
-    tag: {
-      default: 'button',
-      type: String
-    },
-    disabled: {
-      default: false,
-      type: Boolean
-    },
-    subtle: {
-      default: false,
-      type: Boolean
-    },
-    noStyle: {
-      default: false,
-      type: Boolean
-    }
-  }
-}
-</script>

--- a/components/base/divider.vue
+++ b/components/base/divider.vue
@@ -2,14 +2,14 @@
   <hr class="my-2 border-t border-gray-200 dark:border-gray-600">
 </template>
 
-<style lang="scss" scoped>
-hr {
-  height: 0;
-}
-</style>
-
 <script>
 export default {
   name: 'Divider'
 }
 </script>
+
+<style lang="scss" scoped>
+hr {
+  height: 0;
+}
+</style>

--- a/components/base/option.vue
+++ b/components/base/option.vue
@@ -13,6 +13,27 @@
   </button>
 </template>
 
+<script>
+export default {
+  props: {
+    translationKey: {
+      type: String,
+      default: ''
+    },
+
+    translationSubkey: {
+      type: String,
+      default: ''
+    },
+
+    active: {
+      type: Boolean,
+      default: false
+    }
+  }
+}
+</script>
+
 <style lang="postcss" scoped>
 .select-option {
   @apply px-3 py-4 border border-solid border-gray-300 rounded-md bg-white text-left;
@@ -39,24 +60,3 @@
   @apply text-sm text-opacity-75;
 }
 </style>
-
-<script>
-export default {
-  props: {
-    translationKey: {
-      type: String,
-      default: ''
-    },
-
-    translationSubkey: {
-      type: String,
-      default: ''
-    },
-
-    active: {
-      type: Boolean,
-      default: false
-    }
-  }
-}
-</script>

--- a/components/base/optionGroup.vue
+++ b/components/base/optionGroup.vue
@@ -12,12 +12,6 @@
   </div>
 </template>
 
-<style lang="postcss">
-.select-option:not(:last-child) {
-  @apply mr-2;
-}
-</style>
-
 <script>
 export default {
   components: {
@@ -56,3 +50,9 @@ export default {
   }
 }
 </script>
+
+<style lang="postcss">
+.select-option:not(:last-child) {
+  @apply mr-2;
+}
+</style>

--- a/components/base/overlay.vue
+++ b/components/base/overlay.vue
@@ -4,6 +4,18 @@
   </div>
 </template>
 
+<script>
+export default {
+  props: {
+    opacity: {
+      type: Number,
+      default: 0.3,
+      validator (value) { return value >= 0 && value <= 1 }
+    }
+  }
+}
+</script>
+
 <style lang="scss" scoped>
 div.ui-overlay {
   @apply w-full h-full fixed bg-transparent overflow-hidden;
@@ -16,15 +28,3 @@ div.ui-overlay {
   z-index: 1001;
 }
 </style>
-
-<script>
-export default {
-  props: {
-    opacity: {
-      type: Number,
-      default: 0.3,
-      validator (value) { return value >= 0 && value <= 1 }
-    }
-  }
-}
-</script>

--- a/components/schedule/scheduleDisplay.vue
+++ b/components/schedule/scheduleDisplay.vue
@@ -13,10 +13,18 @@
       />
     </transition-group>
     <div v-if="$store.state.settings.schedule.visibility.showSectionType" class="section-type">
-      {{ $i18n.t('section.' + this.$store.getters['schedule/getCurrentItem'].type).toLowerCase() }}
+      {{ $i18n.t('section.' + $store.getters['schedule/getCurrentItem'].type).toLowerCase() }}
     </div>
   </div>
 </template>
+
+<script>
+export default {
+  components: {
+    ScheduleItem: () => import(/* webpackMode: "eager" */ '@/components/schedule/scheduleItem.vue')
+  }
+}
+</script>
 
 <style lang="scss" scoped>
 div.schedule-container {
@@ -54,11 +62,3 @@ div.section-type {
   @apply bg-gray-700 text-center text-gray-50 py-2;
 }
 </style>
-
-<script>
-export default {
-  components: {
-    ScheduleItem: () => import(/* webpackMode: "eager" */ '@/components/schedule/scheduleItem.vue')
-  }
-}
-</script>

--- a/components/schedule/scheduleItem.vue
+++ b/components/schedule/scheduleItem.vue
@@ -11,6 +11,21 @@
   />
 </template>
 
+<script>
+export default {
+  props: {
+    data: {
+      type: Object,
+      default: () => {}
+    },
+    active: {
+      type: Boolean,
+      default: false
+    }
+  }
+}
+</script>
+
 <style lang="scss" scoped>
 .schedule-item {
   display: inline-block;
@@ -40,18 +55,3 @@
 //   // border-color: #757575;
 // }
 </style>
-
-<script>
-export default {
-  props: {
-    data: {
-      type: Object,
-      default: () => {}
-    },
-    active: {
-      type: Boolean,
-      default: false
-    }
-  }
-}
-</script>

--- a/components/settings/baseSettingsItemBare.vue
+++ b/components/settings/baseSettingsItemBare.vue
@@ -34,14 +34,6 @@
   </section>
 </template>
 
-<style lang="postcss" scoped>
-.disabled {
-  @apply opacity-50 cursor-default;
-
-  pointer-events: none;
-}
-</style>
-
 <script>
 export default {
   props: {
@@ -94,3 +86,11 @@ export default {
   }
 }
 </script>
+
+<style lang="postcss" scoped>
+.disabled {
+  @apply opacity-50 cursor-default;
+
+  pointer-events: none;
+}
+</style>

--- a/components/timer/controls/basic.vue
+++ b/components/timer/controls/basic.vue
@@ -44,6 +44,49 @@
   </div>
 </template>
 
+<script>
+import KeyboardListener from '@/assets/mixins/keyboardListener'
+
+export default {
+  components: {
+    // UiButton: () => import(/* webpackChunkName: "uibase" */ '@/components/base/button.vue'),
+    IconPlay: () => import('vue-material-design-icons/Play.vue'),
+    IconPause: () => import('vue-material-design-icons/Pause.vue'),
+    IconStop: () => import('vue-material-design-icons/Stop.vue'),
+    IconSkipNext: () => import('vue-material-design-icons/SkipNext.vue')
+  },
+
+  mixins: [KeyboardListener],
+
+  computed: {
+    progressPercentage () {
+      return this.$store.getters['schedule/getCurrentItem'].timeElapsed / this.$store.getters['schedule/getCurrentItem'].length
+    }
+  },
+
+  methods: {
+    mixin_keyboardListener_handleKeyUp (e) {
+      if (!this.canUseKeyboard || !this.$store.state.settings.timerControls.enableKeyboardShortcuts) { return }
+      if (e.code.toLowerCase() === 'space') {
+        this.playPause()
+      }
+    },
+
+    playPause () {
+      this.$store.commit('schedule/updateTimerState', this.$store.getters['schedule/getCurrentTimerState'] !== 1 ? 1 : 2)
+    },
+
+    reset () {
+      this.$store.commit('schedule/updateTimerState', 0)
+    },
+
+    advance () {
+      this.$store.commit('schedule/advance')
+    }
+  }
+}
+</script>
+
 <style lang="scss" scoped>
 div.timer-control-panel-basic {
   @apply p-2 bg-transparent flex flex-row items-center mb-4;
@@ -148,46 +191,3 @@ div.play-button:not(.active):hover::after {
 }
 
 </style>
-
-<script>
-import KeyboardListener from '@/assets/mixins/keyboardListener'
-
-export default {
-  components: {
-    // UiButton: () => import(/* webpackChunkName: "uibase" */ '@/components/base/button.vue'),
-    IconPlay: () => import('vue-material-design-icons/Play.vue'),
-    IconPause: () => import('vue-material-design-icons/Pause.vue'),
-    IconStop: () => import('vue-material-design-icons/Stop.vue'),
-    IconSkipNext: () => import('vue-material-design-icons/SkipNext.vue')
-  },
-
-  mixins: [KeyboardListener],
-
-  computed: {
-    progressPercentage () {
-      return this.$store.getters['schedule/getCurrentItem'].timeElapsed / this.$store.getters['schedule/getCurrentItem'].length
-    }
-  },
-
-  methods: {
-    mixin_keyboardListener_handleKeyUp (e) {
-      if (!this.canUseKeyboard || !this.$store.state.settings.timerControls.enableKeyboardShortcuts) { return }
-      if (e.code.toLowerCase() === 'space') {
-        this.playPause()
-      }
-    },
-
-    playPause () {
-      this.$store.commit('schedule/updateTimerState', this.$store.getters['schedule/getCurrentTimerState'] !== 1 ? 1 : 2)
-    },
-
-    reset () {
-      this.$store.commit('schedule/updateTimerState', 0)
-    },
-
-    advance () {
-      this.$store.commit('schedule/advance')
-    }
-  }
-}
-</script>

--- a/components/timer/display/_timerSwitch.vue
+++ b/components/timer/display/_timerSwitch.vue
@@ -9,38 +9,6 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
-div.timer-container {
-  @apply w-full h-full;
-
-  z-index: 5;
-  position: relative;
-}
-
-div.timer-display {
-  transition: 300ms ease-in;
-  transition-property: opacity;
-  opacity: 0.7;
-  user-select: none;
-  -moz-user-select: none;
-  -webkit-user-select: none;
-}
-
-div.timer-display.active {
-  opacity: 1;
-}
-
-.timer-switch-enter-active,
-.timer-switch-leave-active {
-  transition: opacity 0.5s ease-out;
-}
-
-.timer-switch-enter,
-.timer-switch-leave-to {
-  opacity: 0 !important;
-}
-</style>
-
 <script>
 import { AvailableTimers } from '@/store/settings'
 import TimerMixin from '@/assets/mixins/timerMixin'
@@ -73,3 +41,35 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+div.timer-container {
+  @apply w-full h-full;
+
+  z-index: 5;
+  position: relative;
+}
+
+div.timer-display {
+  transition: 300ms ease-in;
+  transition-property: opacity;
+  opacity: 0.7;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+}
+
+div.timer-display.active {
+  opacity: 1;
+}
+
+.timer-switch-enter-active,
+.timer-switch-leave-active {
+  transition: opacity 0.5s ease-out;
+}
+
+.timer-switch-enter,
+.timer-switch-leave-to {
+  opacity: 0 !important;
+}
+</style>

--- a/components/timer/display/timerComplete.vue
+++ b/components/timer/display/timerComplete.vue
@@ -4,13 +4,6 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
-.timer-complete-icon svg {
-  width: 20vw !important;
-  height: 20vw !important;
-}
-</style>
-
 <script>
 import CompleteIcon from 'vue-material-design-icons/Check.vue'
 
@@ -18,3 +11,10 @@ export default {
   components: { CompleteIcon }
 }
 </script>
+
+<style lang="scss" scoped>
+.timer-complete-icon svg {
+  width: 20vw !important;
+  height: 20vw !important;
+}
+</style>

--- a/components/timer/display/traditional.vue
+++ b/components/timer/display/traditional.vue
@@ -4,6 +4,14 @@
   </div>
 </template>
 
+<script>
+import TimerMixin from '@/assets/mixins/timerMixin'
+
+export default {
+  mixins: [TimerMixin]
+}
+</script>
+
 <style lang="scss" scoped>
 @import '@/assets/scss/SourceSansPro_Numbers.scss';
 
@@ -16,11 +24,3 @@
   letter-spacing: 0.5rem;
 }
 </style>
-
-<script>
-import TimerMixin from '@/assets/mixins/timerMixin'
-
-export default {
-  mixins: [TimerMixin]
-}
-</script>

--- a/components/timer/timerControls.vue
+++ b/components/timer/timerControls.vue
@@ -37,13 +37,6 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
-  div.timer-control-panel {
-    width: max-content;
-    z-index: 10;
-  }
-</style>
-
 <script>
 export default {
   components: {
@@ -62,3 +55,10 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+  div.timer-control-panel {
+    width: max-content;
+    z-index: 10;
+  }
+</style>

--- a/layouts/timer.vue
+++ b/layouts/timer.vue
@@ -7,17 +7,6 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
-.timer-app-bar {
-  position: fixed;
-  width: max-content;
-}
-
-footer.timer-footer {
-  background-color: transparent;
-}
-</style>
-
 <script>
 export default {
   components: {
@@ -47,3 +36,14 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.timer-app-bar {
+  position: fixed;
+  width: max-content;
+}
+
+footer.timer-footer {
+  background-color: transparent;
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -139,6 +139,80 @@
   </div>
 </template>
 
+<script>
+import IconLightBulb from 'vue-material-design-icons/LightbulbOn.vue'
+import IconCheck from 'vue-material-design-icons/CheckBold.vue'
+import IconHand from 'vue-material-design-icons/Handshake.vue'
+import IconGithub from 'vue-material-design-icons/Github.vue'
+import IconRepeat from 'vue-material-design-icons/Repeat.vue'
+
+export default {
+  components: {
+    IconLightBulb, IconCheck, IconHand, IconGithub, IconRepeat
+  },
+
+  data () {
+    return {
+      productImgTop: true,
+      productImgIntersection: null,
+      features: [
+        { icon: 'IconLightBulb', iconClass: 'text-yellow-500' },
+        { icon: 'IconCheck', iconClass: 'text-green-600' },
+        { icon: 'IconHand', iconClass: 'text-blue-600' }
+      ],
+      scheduleCards: [
+        { bg: 'bg-red-100', border: 'border-red-400', info: true },
+        { bg: 'bg-yellow-100', info: true },
+        { bg: 'bg-blue-100', border: 'border-blue-400', info: false }
+      ],
+      faq: [
+        { q: 'change_timers' },
+        { q: 'will_it_help', hint: true },
+        { q: 'data_collection' },
+        { q: 'remember_settings', hint: true },
+        { q: 'need_to_know' },
+        { q: 'timer_style' }
+      ],
+      smallFeatures: [
+        'customization', 'notifications', 'flexible', 'pwa', 'opensource', 'notrackers', 'noads',
+        'clean', 'adaptiveticking', 'localization', 'more'
+      ]
+    }
+  },
+
+  head () {
+    return {
+      title: 'AnotherPomodoro'
+    }
+  },
+
+  mounted () {
+    const thisRef = this
+
+    this.productImgIntersection = new IntersectionObserver(
+      function (entries, observer) {
+        // scroll the image to bottom if its top is outside the viewport
+        if (entries[0].boundingClientRect.top < 0) {
+          thisRef.productImgTop = false
+        } else {
+          thisRef.productImgTop = true
+        }
+      },
+      {
+        threshold: [1]
+        // rootMargin: '60px 0px 0px 0px'
+      }
+    )
+
+    this.productImgIntersection.observe(this.$refs.productImg)
+  },
+
+  beforeDestroy () {
+    this.productImgIntersection.disconnect()
+  }
+}
+</script>
+
 <style lang="scss" scoped>
 h1 {
   @apply text-5xl;
@@ -367,77 +441,3 @@ h2 {
   }
 }
 </style>
-
-<script>
-import IconLightBulb from 'vue-material-design-icons/LightbulbOn.vue'
-import IconCheck from 'vue-material-design-icons/CheckBold.vue'
-import IconHand from 'vue-material-design-icons/Handshake.vue'
-import IconGithub from 'vue-material-design-icons/Github.vue'
-import IconRepeat from 'vue-material-design-icons/Repeat.vue'
-
-export default {
-  components: {
-    IconLightBulb, IconCheck, IconHand, IconGithub, IconRepeat
-  },
-
-  data () {
-    return {
-      productImgTop: true,
-      productImgIntersection: null,
-      features: [
-        { icon: 'IconLightBulb', iconClass: 'text-yellow-500' },
-        { icon: 'IconCheck', iconClass: 'text-green-600' },
-        { icon: 'IconHand', iconClass: 'text-blue-600' }
-      ],
-      scheduleCards: [
-        { bg: 'bg-red-100', border: 'border-red-400', info: true },
-        { bg: 'bg-yellow-100', info: true },
-        { bg: 'bg-blue-100', border: 'border-blue-400', info: false }
-      ],
-      faq: [
-        { q: 'change_timers' },
-        { q: 'will_it_help', hint: true },
-        { q: 'data_collection' },
-        { q: 'remember_settings', hint: true },
-        { q: 'need_to_know' },
-        { q: 'timer_style' }
-      ],
-      smallFeatures: [
-        'customization', 'notifications', 'flexible', 'pwa', 'opensource', 'notrackers', 'noads',
-        'clean', 'adaptiveticking', 'localization', 'more'
-      ]
-    }
-  },
-
-  mounted () {
-    const thisRef = this
-
-    this.productImgIntersection = new IntersectionObserver(
-      function (entries, observer) {
-        // scroll the image to bottom if its top is outside the viewport
-        if (entries[0].boundingClientRect.top < 0) {
-          thisRef.productImgTop = false
-        } else {
-          thisRef.productImgTop = true
-        }
-      },
-      {
-        threshold: [1]
-        // rootMargin: '60px 0px 0px 0px'
-      }
-    )
-
-    this.productImgIntersection.observe(this.$refs.productImg)
-  },
-
-  beforeDestroy () {
-    this.productImgIntersection.disconnect()
-  },
-
-  head () {
-    return {
-      title: 'AnotherPomodoro'
-    }
-  }
-}
-</script>

--- a/pages/setup.vue
+++ b/pages/setup.vue
@@ -39,66 +39,6 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
-section.setup-panel {
-  @apply bg-gray-100 border border-gray-300 shadow-xl rounded-lg -mt-8 divide-y divide-gray-400;
-
-  & > .step {
-    @apply p-4;
-
-    & > h1 {
-      @apply text-2xl font-bold uppercase text-gray-800 mb-2;
-    }
-
-    & > .content {
-      @apply overflow-hidden scale-y-0 transform;
-
-      transition: transform 500ms ease-out;
-    }
-
-    &.active > .content {
-      @apply scale-y-100;
-    }
-
-    & > .description {
-      @apply text-black text-opacity-90 -mt-1;
-    }
-  }
-
-  div.preset-card {
-    @apply bg-gray-50 p-3 border border-gray-200 text-black cursor-pointer select-none;
-
-    h1 {
-      @apply text-lg;
-
-      & > span.title {
-        @apply font-bold uppercase;
-      }
-
-      & > span.preview {
-        @apply float-right;
-      }
-    }
-
-    & > div.description {
-      @apply text-opacity-80 text-black;
-    }
-
-    &.selected {
-      @apply bg-primary text-white shadow-md;
-
-      & > div.description {
-        @apply text-white;
-      }
-    }
-  }
-
-  .finish-button {
-    @apply bg-green-600 text-white font-bold text-lg text-center p-2 rounded-lg border border-green-700 uppercase hover:bg-green-700 cursor-pointer m-4 mt-0;
-  }
-}
-</style>
-
 <script>
 import { AvailableTimers } from '@/store/settings'
 
@@ -162,6 +102,12 @@ export default {
     }
   },
 
+  head () {
+    return {
+      title: `AnotherPomodoro: ${this.$i18n.t('setup.head').toLowerCase()}`
+    }
+  },
+
   methods: {
     applyFinalSettings () {
       const finalOptions = {
@@ -172,12 +118,66 @@ export default {
 
       this.$router.push('/timer')
     }
-  },
-
-  head () {
-    return {
-      title: `AnotherPomodoro: ${this.$i18n.t('setup.head').toLowerCase()}`
-    }
   }
 }
 </script>
+
+<style lang="scss" scoped>
+section.setup-panel {
+  @apply bg-gray-100 border border-gray-300 shadow-xl rounded-lg -mt-8 divide-y divide-gray-400;
+
+  & > .step {
+    @apply p-4;
+
+    & > h1 {
+      @apply text-2xl font-bold uppercase text-gray-800 mb-2;
+    }
+
+    & > .content {
+      @apply overflow-hidden scale-y-0 transform;
+
+      transition: transform 500ms ease-out;
+    }
+
+    &.active > .content {
+      @apply scale-y-100;
+    }
+
+    & > .description {
+      @apply text-black text-opacity-90 -mt-1;
+    }
+  }
+
+  div.preset-card {
+    @apply bg-gray-50 p-3 border border-gray-200 text-black cursor-pointer select-none;
+
+    h1 {
+      @apply text-lg;
+
+      & > span.title {
+        @apply font-bold uppercase;
+      }
+
+      & > span.preview {
+        @apply float-right;
+      }
+    }
+
+    & > div.description {
+      @apply text-opacity-80 text-black;
+    }
+
+    &.selected {
+      @apply bg-primary text-white shadow-md;
+
+      & > div.description {
+        @apply text-white;
+      }
+    }
+  }
+
+  .finish-button {
+    @apply bg-green-600 text-white font-bold text-lg text-center p-2 rounded-lg border border-green-700 uppercase hover:bg-green-700 cursor-pointer m-4 mt-0;
+  }
+}
+</style>


### PR DESCRIPTION
Change the order of `<script>` and `<style>` tags in component, page and layout files to fix the new `vue/component-tag-order` warning and improve consistency.