### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.10.0](https://github.com/Hanziness/AnotherPomodoro/compare/v0.9.7...v0.10.0) (2021-07-12)
+
+
+### Features
+
+* Add dark mode ([#97](https://github.com/Hanziness/AnotherPomodoro/issues/97)) ([3da8e41](https://github.com/Hanziness/AnotherPomodoro/commit/3da8e41bc7eae02e923abcbbb2a5fb77e13cd572))
+* **seo:** Add meta descriptions to the setup and timer pages ([a5a506b](https://github.com/Hanziness/AnotherPomodoro/commit/a5a506b55d4685382fcefe3af1ca5f785b432f19))
+
+
+### Bug Fixes
+
+* Fix Vue warnings related to component names ([0497ec8](https://github.com/Hanziness/AnotherPomodoro/commit/0497ec885a15cbd0f965df43c993e28e4a1090bc))
+* Improve progress bar behaviour on skip ([8e8f12a](https://github.com/Hanziness/AnotherPomodoro/commit/8e8f12abe2616710f00b7e8a387f4eb408b2e369))
+* Language should now be permanent across pages ([9fad494](https://github.com/Hanziness/AnotherPomodoro/commit/9fad494b2ac41e8f7aad7cdfb5c36c2678b924b2))
+
+
+### Refactors
+
+* Fix `vue/component-tag-order` warnings ([#98](https://github.com/Hanziness/AnotherPomodoro/issues/98)) ([96a9c10](https://github.com/Hanziness/AnotherPomodoro/commit/96a9c109357e954f5f832e404358c54f565aac6c))
+
 ### [0.9.7](https://github.com/Hanziness/AnotherPomodoro/compare/v0.9.2...v0.9.7) (2021-07-07)
 
 ### [0.9.6](https://github.com/Hanziness/AnotherPomodoro/compare/v0.9.2...v0.9.6) (2021-06-16)

--- a/components/base/button.vue
+++ b/components/base/button.vue
@@ -27,6 +27,7 @@
 
 .ui-button.regular:hover:not(:disabled) {
   @apply bg-gray-500;
+  @apply dark:bg-gray-50 dark:bg-opacity-20;
 }
 
 .ui-button.regular:active:not(:disabled) {
@@ -39,10 +40,12 @@
 
 .ui-button.subtle:hover {
   @apply bg-gray-200;
+  @apply dark:bg-gray-50 dark:bg-opacity-20;
 }
 
 .ui-button.subtle:active {
   @apply bg-gray-400;
+  @apply dark:bg-gray-50 dark:bg-opacity-40;
 }
 
 .ui-button.disabled {

--- a/components/base/button.vue
+++ b/components/base/button.vue
@@ -16,6 +16,30 @@
   </Component>
 </template>
 
+<script>
+export default {
+  name: 'ControlButton',
+  props: {
+    tag: {
+      default: 'button',
+      type: String
+    },
+    disabled: {
+      default: false,
+      type: Boolean
+    },
+    subtle: {
+      default: false,
+      type: Boolean
+    },
+    noStyle: {
+      default: false,
+      type: Boolean
+    }
+  }
+}
+</script>
+
 <style lang="scss" scoped>
 .ui-button {
   transition: background-color 0.1s ease-out;
@@ -54,27 +78,3 @@
   opacity: 0.5;
 }
 </style>
-
-<script>
-export default {
-  name: 'ControlButton',
-  props: {
-    tag: {
-      default: 'button',
-      type: String
-    },
-    disabled: {
-      default: false,
-      type: Boolean
-    },
-    subtle: {
-      default: false,
-      type: Boolean
-    },
-    noStyle: {
-      default: false,
-      type: Boolean
-    }
-  }
-}
-</script>

--- a/components/base/divider.vue
+++ b/components/base/divider.vue
@@ -1,5 +1,5 @@
 <template>
-  <hr class="my-2">
+  <hr class="my-2 border-t border-gray-200 dark:border-gray-600">
 </template>
 
 <style lang="scss" scoped>

--- a/components/base/divider.vue
+++ b/components/base/divider.vue
@@ -2,14 +2,14 @@
   <hr class="my-2 border-t border-gray-200 dark:border-gray-600">
 </template>
 
-<style lang="scss" scoped>
-hr {
-  height: 0;
-}
-</style>
-
 <script>
 export default {
   name: 'Divider'
 }
 </script>
+
+<style lang="scss" scoped>
+hr {
+  height: 0;
+}
+</style>

--- a/components/base/option.vue
+++ b/components/base/option.vue
@@ -16,12 +16,14 @@
 <style lang="postcss" scoped>
 .select-option {
   @apply px-3 py-4 border border-solid border-gray-300 rounded-md bg-white text-left;
+  @apply dark:bg-gray-800 dark:border-gray-600;
 
   flex-basis: 0;
   transition: background-color 100ms ease-out, color 100ms ease-out;
 
   &:hover {
     @apply bg-gray-200;
+    @apply dark:bg-gray-600;
   }
 
   &.active {

--- a/components/base/option.vue
+++ b/components/base/option.vue
@@ -13,6 +13,27 @@
   </button>
 </template>
 
+<script>
+export default {
+  props: {
+    translationKey: {
+      type: String,
+      default: ''
+    },
+
+    translationSubkey: {
+      type: String,
+      default: ''
+    },
+
+    active: {
+      type: Boolean,
+      default: false
+    }
+  }
+}
+</script>
+
 <style lang="postcss" scoped>
 .select-option {
   @apply px-3 py-4 border border-solid border-gray-300 rounded-md bg-white text-left;
@@ -39,24 +60,3 @@
   @apply text-sm text-opacity-75;
 }
 </style>
-
-<script>
-export default {
-  props: {
-    translationKey: {
-      type: String,
-      default: ''
-    },
-
-    translationSubkey: {
-      type: String,
-      default: ''
-    },
-
-    active: {
-      type: Boolean,
-      default: false
-    }
-  }
-}
-</script>

--- a/components/base/optionGroup.vue
+++ b/components/base/optionGroup.vue
@@ -12,12 +12,6 @@
   </div>
 </template>
 
-<style lang="postcss">
-.select-option:not(:last-child) {
-  @apply mr-2;
-}
-</style>
-
 <script>
 export default {
   components: {
@@ -56,3 +50,9 @@ export default {
   }
 }
 </script>
+
+<style lang="postcss">
+.select-option:not(:last-child) {
+  @apply mr-2;
+}
+</style>

--- a/components/base/overlay.vue
+++ b/components/base/overlay.vue
@@ -4,6 +4,18 @@
   </div>
 </template>
 
+<script>
+export default {
+  props: {
+    opacity: {
+      type: Number,
+      default: 0.3,
+      validator (value) { return value >= 0 && value <= 1 }
+    }
+  }
+}
+</script>
+
 <style lang="scss" scoped>
 div.ui-overlay {
   @apply w-full h-full fixed bg-transparent overflow-hidden;
@@ -16,15 +28,3 @@ div.ui-overlay {
   z-index: 1001;
 }
 </style>
-
-<script>
-export default {
-  props: {
-    opacity: {
-      type: Number,
-      default: 0.3,
-      validator (value) { return value >= 0 && value <= 1 }
-    }
-  }
-}
-</script>

--- a/components/schedule/scheduleDisplay.vue
+++ b/components/schedule/scheduleDisplay.vue
@@ -13,10 +13,18 @@
       />
     </transition-group>
     <div v-if="$store.state.settings.schedule.visibility.showSectionType" class="section-type">
-      {{ $i18n.t('section.' + this.$store.getters['schedule/getCurrentItem'].type).toLowerCase() }}
+      {{ $i18n.t('section.' + $store.getters['schedule/getCurrentItem'].type).toLowerCase() }}
     </div>
   </div>
 </template>
+
+<script>
+export default {
+  components: {
+    ScheduleItem: () => import(/* webpackMode: "eager" */ '@/components/schedule/scheduleItem.vue')
+  }
+}
+</script>
 
 <style lang="scss" scoped>
 div.schedule-container {
@@ -54,11 +62,3 @@ div.section-type {
   @apply bg-gray-700 text-center text-gray-50 py-2;
 }
 </style>
-
-<script>
-export default {
-  components: {
-    ScheduleItem: () => import(/* webpackMode: "eager" */ '@/components/schedule/scheduleItem.vue')
-  }
-}
-</script>

--- a/components/schedule/scheduleItem.vue
+++ b/components/schedule/scheduleItem.vue
@@ -11,6 +11,21 @@
   />
 </template>
 
+<script>
+export default {
+  props: {
+    data: {
+      type: Object,
+      default: () => {}
+    },
+    active: {
+      type: Boolean,
+      default: false
+    }
+  }
+}
+</script>
+
 <style lang="scss" scoped>
 .schedule-item {
   display: inline-block;
@@ -40,18 +55,3 @@
 //   // border-color: #757575;
 // }
 </style>
-
-<script>
-export default {
-  props: {
-    data: {
-      type: Object,
-      default: () => {}
-    },
-    active: {
-      type: Boolean,
-      default: false
-    }
-  }
-}
-</script>

--- a/components/settings/baseSettingsItemBare.vue
+++ b/components/settings/baseSettingsItemBare.vue
@@ -10,7 +10,7 @@
             {{ $i18n.t(translationKey + '._title') }}
           </slot>
         </div>
-        <div v-if="showDescription" class="text-gray-800 text-sm truncate">
+        <div v-if="showDescription" class="text-black text-opacity-75 dark:text-gray-50 dark:text-opacity-75 text-sm truncate">
           <slot name="item-subtitle">
             {{ $i18n.t(translationKey + '._description') }}
           </slot>

--- a/components/settings/baseSettingsItemBare.vue
+++ b/components/settings/baseSettingsItemBare.vue
@@ -34,14 +34,6 @@
   </section>
 </template>
 
-<style lang="postcss" scoped>
-.disabled {
-  @apply opacity-50 cursor-default;
-
-  pointer-events: none;
-}
-</style>
-
 <script>
 export default {
   props: {
@@ -94,3 +86,11 @@ export default {
   }
 }
 </script>
+
+<style lang="postcss" scoped>
+.disabled {
+  @apply opacity-50 cursor-default;
+
+  pointer-events: none;
+}
+</style>

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -70,6 +70,8 @@
             </div>
 
             <div v-if="activeTab === 3" :key="3" class="settings-tab">
+              <settings-check :settings-key="['visuals', 'darkMode']" />
+              <divider />
               <settings-options :settings-key="['currentTimer']" :values="{traditional: 'traditional', approximate: 'approximate', percentage: 'percentage'}" />
               <divider />
               <settings-check :settings-key="['schedule', 'visibility', 'enabled']" />
@@ -186,10 +188,24 @@ export default {
 section.settings-panel {
   & input {
     @apply rounded-md border-gray-300 bg-gray-100 focus:bg-white focus:ring-primary;
+    @apply dark:bg-gray-800 dark:focus:bg-gray-600 dark:text-gray-100 dark:border-gray-700;
+    @apply transition-colors;
   }
 
   & input[type="checkbox"] {
     @apply text-primary;
+
+    &:hover {
+      @apply dark:bg-gray-500 bg-gray-200;
+    }
+
+    &:checked {
+      @apply dark:bg-primary dark:border-primary;
+
+      &:hover {
+        background-color: scale-color(#3498db, $lightness: 30%);
+      }
+    }
   }
 }
 </style>
@@ -197,6 +213,7 @@ section.settings-panel {
 <style lang="scss" scoped>
 section.settings-panel {
   @apply bg-white h-full fixed shadow w-2/5 flex flex-col;
+  @apply dark:bg-gray-900 dark:text-gray-50;
 
   z-index: 1001;
   min-width: calc(min(600px, 100%));
@@ -216,6 +233,7 @@ div.settings-panel-menubar {
 
 div.tab-header {
   @apply flex-1 h-full bg-gray-200 p-2 cursor-pointer text-center flex items-center justify-center select-none;
+  @apply dark:bg-gray-800;
 
   transition: border-color 0.2s ease-out;
   box-sizing: border-box;
@@ -249,17 +267,20 @@ div.settings-tab {
 
 div.reset-button {
   @apply w-full p-4 text-black bg-gray-200 text-lg cursor-pointer transition-colors rounded-lg relative;
+  @apply dark:bg-gray-700 dark:text-gray-50;
 
   &:hover:not(.active) {
     @apply bg-red-500 text-white;
+    @apply dark:bg-red-700;
   }
 
   &:active {
     @apply bg-red-600 text-white;
+    @apply dark:bg-red-800;
   }
 
   &.active {
-    @apply bg-gray-200 text-black cursor-default;
+    @apply bg-gray-200 text-black dark:bg-gray-600 dark:text-white cursor-default;
   }
 
   & .reset-subbutton {

--- a/components/taskList/taskWindow.vue
+++ b/components/taskList/taskWindow.vue
@@ -159,7 +159,7 @@ export default {
 <style lang="scss" scoped>
 div.tasks-window {
   @apply py-2 rounded-lg bg-gray-100 border border-gray-200 text-gray-900 shadow-xl absolute z-20 max-w-lg max-h-96 flex flex-col;
-  // @apply dark:bg-gray-900 dark:text-white;
+  @apply dark:bg-gray-800 dark:text-gray-50 dark:border-gray-600;
 
   & > .header {
     @apply uppercase font-bold text-lg pl-4 pr-2;
@@ -169,6 +169,7 @@ div.tasks-window {
 
       & > .header-toggle {
         @apply rounded-full bg-gray-200 mr-1 p-1;
+        @apply dark:bg-gray-500 dark:bg-opacity-25;
 
         &:last-child {
           @apply mr-0;
@@ -176,6 +177,7 @@ div.tasks-window {
 
         &.active {
           @apply bg-gray-700 text-white;
+          @apply dark:bg-gray-400 dark:bg-opacity-100;
         }
 
         &.disabled {
@@ -187,7 +189,7 @@ div.tasks-window {
 
   & > .list {
     @apply grid grid-flow-row divide-y divide-gray-300 overflow-y-scroll flex-shrink overflow-x-hidden;
-    // @apply dark:divide-gray-500;
+    @apply dark:divide-gray-500;
 
     & > .list-item {
       @apply flex flex-row items-center px-4 py-2; // h-11
@@ -213,7 +215,7 @@ div.tasks-window {
 
         & > .description {
           @apply text-black text-opacity-80 text-sm overflow-ellipsis;
-          // @apply dark:text-white;
+          @apply dark:text-gray-100 dark:text-opacity-80;
         }
       }
 
@@ -222,12 +224,12 @@ div.tasks-window {
 
         & > .priority {
           @apply text-black text-opacity-60 text-sm mr-2 w-4 text-right flex flex-col justify-center;
-          // @apply dark:text-white;
+          @apply dark:text-gray-100;
         }
 
         & > .priority-change-button {
           @apply rounded-full bg-gray-700 bg-opacity-0 hover:bg-opacity-30;
-          // @apply dark:bg-white;
+          @apply dark:bg-transparent;
 
           &.disabled {
             @apply pointer-events-none opacity-40;
@@ -238,7 +240,7 @@ div.tasks-window {
   }
 
   & > .empty {
-    @apply mx-4 my-2 text-black text-opacity-80;
+    @apply mx-4 my-2 text-black text-opacity-80 dark:text-gray-100 dark:text-opacity-80;
   }
 
   & > .footer {
@@ -251,7 +253,7 @@ div.tasks-window {
       & > input,
       & > select {
         @apply p-2 focus:ring-0 border-gray-200 bg-gray-200 text-gray-900 text-sm;
-        // @apply dark:border-gray-800 dark:bg-gray-800 dark:text-white;
+        @apply dark:border-gray-700 dark:bg-gray-700 dark:text-gray-50;
 
         &:first-child {
           @apply rounded-t-lg;
@@ -263,22 +265,22 @@ div.tasks-window {
 
         &:focus {
           @apply bg-gray-100;
-          // @apply dark:bg-gray-700;
+          @apply dark:bg-gray-600;
         }
       }
 
       & > input.input-desc {
         @apply text-gray-900 text-opacity-80 text-xs;
-        // @apply dark:text-white;
+        @apply dark:text-gray-50;
       }
     }
 
     & > .add-button {
       @apply bg-blue-900 hover:bg-blue-800 text-white rounded-lg p-2 ml-2 select-none flex flex-col justify-center;
-      // @apply dark:bg-gray-100 dark:hover:bg-gray-200 dark:text-black;
+      @apply dark:bg-gray-100 dark:hover:bg-gray-200 dark:text-black;
 
       &.disabled {
-        @apply opacity-60 pointer-events-none;
+        @apply opacity-60 dark:opacity-25 pointer-events-none;
       }
     }
   }

--- a/components/timer/controls/basic.vue
+++ b/components/timer/controls/basic.vue
@@ -78,11 +78,12 @@ div.timer-control-panel-basic {
 
 div.control-button {
   @apply bg-gray-200 cursor-pointer;
+  @apply dark:bg-gray-800;
 
   transition: background-color 200ms ease-out;
 
   &:not(.play-button):hover {
-    @apply bg-gray-300;
+    @apply bg-gray-300 dark:bg-gray-600;
   }
 
   & > * {

--- a/components/timer/controls/basic.vue
+++ b/components/timer/controls/basic.vue
@@ -44,6 +44,49 @@
   </div>
 </template>
 
+<script>
+import KeyboardListener from '@/assets/mixins/keyboardListener'
+
+export default {
+  components: {
+    // UiButton: () => import(/* webpackChunkName: "uibase" */ '@/components/base/button.vue'),
+    IconPlay: () => import('vue-material-design-icons/Play.vue'),
+    IconPause: () => import('vue-material-design-icons/Pause.vue'),
+    IconStop: () => import('vue-material-design-icons/Stop.vue'),
+    IconSkipNext: () => import('vue-material-design-icons/SkipNext.vue')
+  },
+
+  mixins: [KeyboardListener],
+
+  computed: {
+    progressPercentage () {
+      return this.$store.getters['schedule/getCurrentItem'].timeElapsed / this.$store.getters['schedule/getCurrentItem'].length
+    }
+  },
+
+  methods: {
+    mixin_keyboardListener_handleKeyUp (e) {
+      if (!this.canUseKeyboard || !this.$store.state.settings.timerControls.enableKeyboardShortcuts) { return }
+      if (e.code.toLowerCase() === 'space') {
+        this.playPause()
+      }
+    },
+
+    playPause () {
+      this.$store.commit('schedule/updateTimerState', this.$store.getters['schedule/getCurrentTimerState'] !== 1 ? 1 : 2)
+    },
+
+    reset () {
+      this.$store.commit('schedule/updateTimerState', 0)
+    },
+
+    advance () {
+      this.$store.commit('schedule/advance')
+    }
+  }
+}
+</script>
+
 <style lang="scss" scoped>
 div.timer-control-panel-basic {
   @apply p-2 bg-transparent flex flex-row items-center mb-4;
@@ -148,46 +191,3 @@ div.play-button:not(.active):hover::after {
 }
 
 </style>
-
-<script>
-import KeyboardListener from '@/assets/mixins/keyboardListener'
-
-export default {
-  components: {
-    // UiButton: () => import(/* webpackChunkName: "uibase" */ '@/components/base/button.vue'),
-    IconPlay: () => import('vue-material-design-icons/Play.vue'),
-    IconPause: () => import('vue-material-design-icons/Pause.vue'),
-    IconStop: () => import('vue-material-design-icons/Stop.vue'),
-    IconSkipNext: () => import('vue-material-design-icons/SkipNext.vue')
-  },
-
-  mixins: [KeyboardListener],
-
-  computed: {
-    progressPercentage () {
-      return this.$store.getters['schedule/getCurrentItem'].timeElapsed / this.$store.getters['schedule/getCurrentItem'].length
-    }
-  },
-
-  methods: {
-    mixin_keyboardListener_handleKeyUp (e) {
-      if (!this.canUseKeyboard || !this.$store.state.settings.timerControls.enableKeyboardShortcuts) { return }
-      if (e.code.toLowerCase() === 'space') {
-        this.playPause()
-      }
-    },
-
-    playPause () {
-      this.$store.commit('schedule/updateTimerState', this.$store.getters['schedule/getCurrentTimerState'] !== 1 ? 1 : 2)
-    },
-
-    reset () {
-      this.$store.commit('schedule/updateTimerState', 0)
-    },
-
-    advance () {
-      this.$store.commit('schedule/advance')
-    }
-  }
-}
-</script>

--- a/components/timer/display/_timerSwitch.vue
+++ b/components/timer/display/_timerSwitch.vue
@@ -9,38 +9,6 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
-div.timer-container {
-  @apply w-full h-full;
-
-  z-index: 5;
-  position: relative;
-}
-
-div.timer-display {
-  transition: 300ms ease-in;
-  transition-property: opacity;
-  opacity: 0.7;
-  user-select: none;
-  -moz-user-select: none;
-  -webkit-user-select: none;
-}
-
-div.timer-display.active {
-  opacity: 1;
-}
-
-.timer-switch-enter-active,
-.timer-switch-leave-active {
-  transition: opacity 0.5s ease-out;
-}
-
-.timer-switch-enter,
-.timer-switch-leave-to {
-  opacity: 0 !important;
-}
-</style>
-
 <script>
 import { AvailableTimers } from '@/store/settings'
 import TimerMixin from '@/assets/mixins/timerMixin'
@@ -73,3 +41,35 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+div.timer-container {
+  @apply w-full h-full;
+
+  z-index: 5;
+  position: relative;
+}
+
+div.timer-display {
+  transition: 300ms ease-in;
+  transition-property: opacity;
+  opacity: 0.7;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+}
+
+div.timer-display.active {
+  opacity: 1;
+}
+
+.timer-switch-enter-active,
+.timer-switch-leave-active {
+  transition: opacity 0.5s ease-out;
+}
+
+.timer-switch-enter,
+.timer-switch-leave-to {
+  opacity: 0 !important;
+}
+</style>

--- a/components/timer/display/timerComplete.vue
+++ b/components/timer/display/timerComplete.vue
@@ -4,13 +4,6 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
-.timer-complete-icon svg {
-  width: 20vw !important;
-  height: 20vw !important;
-}
-</style>
-
 <script>
 import CompleteIcon from 'vue-material-design-icons/Check.vue'
 
@@ -18,3 +11,10 @@ export default {
   components: { CompleteIcon }
 }
 </script>
+
+<style lang="scss" scoped>
+.timer-complete-icon svg {
+  width: 20vw !important;
+  height: 20vw !important;
+}
+</style>

--- a/components/timer/display/traditional.vue
+++ b/components/timer/display/traditional.vue
@@ -4,6 +4,14 @@
   </div>
 </template>
 
+<script>
+import TimerMixin from '@/assets/mixins/timerMixin'
+
+export default {
+  mixins: [TimerMixin]
+}
+</script>
+
 <style lang="scss" scoped>
 @import '@/assets/scss/SourceSansPro_Numbers.scss';
 
@@ -16,11 +24,3 @@
   letter-spacing: 0.5rem;
 }
 </style>
-
-<script>
-import TimerMixin from '@/assets/mixins/timerMixin'
-
-export default {
-  mixins: [TimerMixin]
-}
-</script>

--- a/components/timer/timerControls.vue
+++ b/components/timer/timerControls.vue
@@ -37,13 +37,6 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
-  div.timer-control-panel {
-    width: max-content;
-    z-index: 10;
-  }
-</style>
-
 <script>
 export default {
   components: {
@@ -62,3 +55,10 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+  div.timer-control-panel {
+    width: max-content;
+    z-index: 10;
+  }
+</style>

--- a/components/timer/timerProgress.vue
+++ b/components/timer/timerProgress.vue
@@ -7,7 +7,10 @@
         'background-color': $store.getters['schedule/getScheduleColour'][scheduleEntryId],
         'transform': `translateX(${-100 + progressPercentage}%)`
       }"
-    />
+    >
+      <!-- Dark mode background override -->
+      <div class="absolute w-full h-full invisible dark:visible dark:bg-white" />
+    </div>
   </transition-group>
 </template>
 
@@ -40,6 +43,8 @@ export default {
 <style lang="scss" scoped>
 // provides a background filling progress bar (parent needs to be position: relative)
 .timer-progress {
+  @apply dark:opacity-20;
+
   transition: 200ms ease-in-out;
   transition-property: background-color transform;
   width: 100%;

--- a/components/timer/timerProgress.vue
+++ b/components/timer/timerProgress.vue
@@ -1,17 +1,15 @@
 <template>
-  <transition-group name="progress-transition" mode="out-in">
-    <div
-      :key="$store.getters['schedule/getCurrentItem'].id"
-      :class="['timer-progress']"
-      :style="{
-        'background-color': $store.getters['schedule/getScheduleColour'][scheduleEntryId],
-        'transform': `translateX(${-100 + progressPercentage}%)`
-      }"
-    >
-      <!-- Dark mode background override -->
-      <div class="absolute w-full h-full invisible dark:visible dark:bg-white" />
-    </div>
-  </transition-group>
+  <div
+    :key="$store.getters['schedule/getCurrentItem'].id"
+    :class="['timer-progress']"
+    :style="{
+      'background-color': $store.getters['schedule/getScheduleColour'][scheduleEntryId],
+      'transform': `translateX(${-100 + progressPercentage}%)`
+    }"
+  >
+    <!-- Dark mode background override -->
+    <div class="absolute w-full h-full invisible dark:visible dark:bg-white" />
+  </div>
 </template>
 
 <script>
@@ -53,18 +51,5 @@ export default {
   display: block;
   top: 0;
   left: 0;
-}
-
-.progress-transition-enter-active,
-.progress-transition-leave-active {
-  transition: 500ms ease-in;
-  transition-property: transform !important;
-}
-
-// .progress-transition-enter {
-// }
-
-.progress-transition-leave-to {
-  transform: translateX(0%) !important;
 }
 </style>

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -89,6 +89,7 @@ export default {
         clean: 'Clean design',
         adaptiveticking: 'Adaptive ticking',
         localization: 'Multiple languages',
+        darkmode: 'Dark mode',
         more: '... and more to come'
       }
     },

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -295,6 +295,12 @@ export default {
           _title: 'Use tick emoji in title',
           _description: 'Show ✔ instead of "done"'
         }
+      },
+      visuals: {
+        darkMode: {
+          _title: 'Enable dark mode',
+          _description: 'Less bright, just as productive'
+        }
       }
     }
   },

--- a/i18n/hu.js
+++ b/i18n/hu.js
@@ -295,6 +295,12 @@ export default {
           _title: 'Pipa jel használata a címsorban',
           _description: 'Mutasson ✔ emojit a "kész" helyett az alkalmazás'
         }
+      },
+      visuals: {
+        darkMode: {
+          _title: 'Sötét téma bekapcsolása',
+          _description: 'Kevesebb fényerő, ugyanannyi produktivitás'
+        }
       }
     }
   },

--- a/i18n/hu.js
+++ b/i18n/hu.js
@@ -89,6 +89,7 @@ export default {
         clean: 'Letisztult megjelenés',
         adaptiveticking: 'Adaptív ketyegés',
         localization: 'Magyarul is tud',
+        darkmode: 'Sötét téma',
         more: '... és még több'
       }
     },

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-
+  name: 'LayoutDefault'
 }
 </script>

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -14,6 +14,7 @@
 
 <script>
 export default {
+  name: 'LayoutError',
   layout: 'empty',
   props: {
     error: {

--- a/layouts/timer.vue
+++ b/layouts/timer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div :class="['page', { 'dark': darkMode }]">
     <nuxt />
     <!-- <portal to="footer">
       <span>&copy; {{ new Date().getFullYear() }}</span>
@@ -24,6 +24,25 @@ export default {
   },
   data () {
     return {
+    }
+  },
+  computed: {
+    darkMode () {
+      return this.$store.state.settings.visuals.darkMode
+    },
+
+    updateFinished () {
+      return this.$store.state.loading.persist_finished
+    }
+  },
+  watch: {
+    updateFinished () {
+      this.$forceUpdate()
+    }
+  },
+  mounted () {
+    if (this.updateFinished) {
+      this.$forceUpdate()
     }
   }
 }

--- a/layouts/timer.vue
+++ b/layouts/timer.vue
@@ -9,6 +9,7 @@
 
 <script>
 export default {
+  name: 'LayoutTimer',
   components: {
   },
   data () {

--- a/layouts/timer.vue
+++ b/layouts/timer.vue
@@ -7,17 +7,6 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
-.timer-app-bar {
-  position: fixed;
-  width: max-content;
-}
-
-footer.timer-footer {
-  background-color: transparent;
-}
-</style>
-
 <script>
 export default {
   components: {
@@ -47,3 +36,14 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.timer-app-bar {
+  position: fixed;
+  width: max-content;
+}
+
+footer.timer-footer {
+  background-color: transparent;
+}
+</style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -143,11 +143,11 @@ export default {
       // If enabled, a cookie is set once a user has been redirected to his
       // preferred language to prevent subsequent redirections
       // Set to false to redirect every time
-      useCookie: false,
+      useCookie: true,
       // Set to override the default domain of the cookie. Defaults to host of the site.
       cookieDomain: null,
       // Cookie name
-      cookieKey: 'i18n_redirected',
+      cookieKey: 'lang',
       // Set to always redirect to value stored in the cookie, not just once
       alwaysRedirect: false,
       // If no locale for the browsers locale is a match, use this one as a fallback

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pomodoro-app",
   "description": "Free and open-source Pomodoro app for everyone, right from your browser!",
-  "version": "0.9.7",
+  "version": "0.10.0",
   "private": true,
   "scripts": {
     "dev": "nuxt",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -139,6 +139,80 @@
   </div>
 </template>
 
+<script>
+import IconLightBulb from 'vue-material-design-icons/LightbulbOn.vue'
+import IconCheck from 'vue-material-design-icons/CheckBold.vue'
+import IconHand from 'vue-material-design-icons/Handshake.vue'
+import IconGithub from 'vue-material-design-icons/Github.vue'
+import IconRepeat from 'vue-material-design-icons/Repeat.vue'
+
+export default {
+  components: {
+    IconLightBulb, IconCheck, IconHand, IconGithub, IconRepeat
+  },
+
+  data () {
+    return {
+      productImgTop: true,
+      productImgIntersection: null,
+      features: [
+        { icon: 'IconLightBulb', iconClass: 'text-yellow-500' },
+        { icon: 'IconCheck', iconClass: 'text-green-600' },
+        { icon: 'IconHand', iconClass: 'text-blue-600' }
+      ],
+      scheduleCards: [
+        { bg: 'bg-red-100', border: 'border-red-400', info: true },
+        { bg: 'bg-yellow-100', info: true },
+        { bg: 'bg-blue-100', border: 'border-blue-400', info: false }
+      ],
+      faq: [
+        { q: 'change_timers' },
+        { q: 'will_it_help', hint: true },
+        { q: 'data_collection' },
+        { q: 'remember_settings', hint: true },
+        { q: 'need_to_know' },
+        { q: 'timer_style' }
+      ],
+      smallFeatures: [
+        'customization', 'notifications', 'flexible', 'pwa', 'opensource', 'notrackers', 'noads',
+        'clean', 'adaptiveticking', 'localization', 'more'
+      ]
+    }
+  },
+
+  head () {
+    return {
+      title: 'AnotherPomodoro'
+    }
+  },
+
+  mounted () {
+    const thisRef = this
+
+    this.productImgIntersection = new IntersectionObserver(
+      function (entries, observer) {
+        // scroll the image to bottom if its top is outside the viewport
+        if (entries[0].boundingClientRect.top < 0) {
+          thisRef.productImgTop = false
+        } else {
+          thisRef.productImgTop = true
+        }
+      },
+      {
+        threshold: [1]
+        // rootMargin: '60px 0px 0px 0px'
+      }
+    )
+
+    this.productImgIntersection.observe(this.$refs.productImg)
+  },
+
+  beforeDestroy () {
+    this.productImgIntersection.disconnect()
+  }
+}
+</script>
+
 <style lang="scss" scoped>
 h1 {
   @apply text-5xl;
@@ -367,77 +441,3 @@ h2 {
   }
 }
 </style>
-
-<script>
-import IconLightBulb from 'vue-material-design-icons/LightbulbOn.vue'
-import IconCheck from 'vue-material-design-icons/CheckBold.vue'
-import IconHand from 'vue-material-design-icons/Handshake.vue'
-import IconGithub from 'vue-material-design-icons/Github.vue'
-import IconRepeat from 'vue-material-design-icons/Repeat.vue'
-
-export default {
-  components: {
-    IconLightBulb, IconCheck, IconHand, IconGithub, IconRepeat
-  },
-
-  data () {
-    return {
-      productImgTop: true,
-      productImgIntersection: null,
-      features: [
-        { icon: 'IconLightBulb', iconClass: 'text-yellow-500' },
-        { icon: 'IconCheck', iconClass: 'text-green-600' },
-        { icon: 'IconHand', iconClass: 'text-blue-600' }
-      ],
-      scheduleCards: [
-        { bg: 'bg-red-100', border: 'border-red-400', info: true },
-        { bg: 'bg-yellow-100', info: true },
-        { bg: 'bg-blue-100', border: 'border-blue-400', info: false }
-      ],
-      faq: [
-        { q: 'change_timers' },
-        { q: 'will_it_help', hint: true },
-        { q: 'data_collection' },
-        { q: 'remember_settings', hint: true },
-        { q: 'need_to_know' },
-        { q: 'timer_style' }
-      ],
-      smallFeatures: [
-        'customization', 'notifications', 'flexible', 'pwa', 'opensource', 'notrackers', 'noads',
-        'clean', 'adaptiveticking', 'localization', 'more'
-      ]
-    }
-  },
-
-  mounted () {
-    const thisRef = this
-
-    this.productImgIntersection = new IntersectionObserver(
-      function (entries, observer) {
-        // scroll the image to bottom if its top is outside the viewport
-        if (entries[0].boundingClientRect.top < 0) {
-          thisRef.productImgTop = false
-        } else {
-          thisRef.productImgTop = true
-        }
-      },
-      {
-        threshold: [1]
-        // rootMargin: '60px 0px 0px 0px'
-      }
-    )
-
-    this.productImgIntersection.observe(this.$refs.productImg)
-  },
-
-  beforeDestroy () {
-    this.productImgIntersection.disconnect()
-  },
-
-  head () {
-    return {
-      title: 'AnotherPomodoro'
-    }
-  }
-}
-</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -147,6 +147,7 @@ import IconGithub from 'vue-material-design-icons/Github.vue'
 import IconRepeat from 'vue-material-design-icons/Repeat.vue'
 
 export default {
+  name: 'PageIndex',
   components: {
     IconLightBulb, IconCheck, IconHand, IconGithub, IconRepeat
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -175,7 +175,7 @@ export default {
       ],
       smallFeatures: [
         'customization', 'notifications', 'flexible', 'pwa', 'opensource', 'notrackers', 'noads',
-        'clean', 'adaptiveticking', 'localization', 'more'
+        'clean', 'adaptiveticking', 'localization', 'darkmode', 'more'
       ]
     }
   },

--- a/pages/setup.vue
+++ b/pages/setup.vue
@@ -43,6 +43,7 @@
 import { AvailableTimers } from '@/store/settings'
 
 export default {
+  name: 'PageSetup',
   data () {
     return {
       step: 0,

--- a/pages/setup.vue
+++ b/pages/setup.vue
@@ -105,7 +105,11 @@ export default {
 
   head () {
     return {
-      title: `AnotherPomodoro: ${this.$i18n.t('setup.head').toLowerCase()}`
+      title: `AnotherPomodoro: ${this.$i18n.t('setup.head').toLowerCase()}`,
+      meta: [{
+        hid: 'description',
+        content: 'Set up AnotherPomdoro for use using this setup page.'
+      }]
     }
   },
 

--- a/pages/setup.vue
+++ b/pages/setup.vue
@@ -39,66 +39,6 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
-section.setup-panel {
-  @apply bg-gray-100 border border-gray-300 shadow-xl rounded-lg -mt-8 divide-y divide-gray-400;
-
-  & > .step {
-    @apply p-4;
-
-    & > h1 {
-      @apply text-2xl font-bold uppercase text-gray-800 mb-2;
-    }
-
-    & > .content {
-      @apply overflow-hidden scale-y-0 transform;
-
-      transition: transform 500ms ease-out;
-    }
-
-    &.active > .content {
-      @apply scale-y-100;
-    }
-
-    & > .description {
-      @apply text-black text-opacity-90 -mt-1;
-    }
-  }
-
-  div.preset-card {
-    @apply bg-gray-50 p-3 border border-gray-200 text-black cursor-pointer select-none;
-
-    h1 {
-      @apply text-lg;
-
-      & > span.title {
-        @apply font-bold uppercase;
-      }
-
-      & > span.preview {
-        @apply float-right;
-      }
-    }
-
-    & > div.description {
-      @apply text-opacity-80 text-black;
-    }
-
-    &.selected {
-      @apply bg-primary text-white shadow-md;
-
-      & > div.description {
-        @apply text-white;
-      }
-    }
-  }
-
-  .finish-button {
-    @apply bg-green-600 text-white font-bold text-lg text-center p-2 rounded-lg border border-green-700 uppercase hover:bg-green-700 cursor-pointer m-4 mt-0;
-  }
-}
-</style>
-
 <script>
 import { AvailableTimers } from '@/store/settings'
 
@@ -162,6 +102,12 @@ export default {
     }
   },
 
+  head () {
+    return {
+      title: `AnotherPomodoro: ${this.$i18n.t('setup.head').toLowerCase()}`
+    }
+  },
+
   methods: {
     applyFinalSettings () {
       const finalOptions = {
@@ -172,12 +118,66 @@ export default {
 
       this.$router.push('/timer')
     }
-  },
-
-  head () {
-    return {
-      title: `AnotherPomodoro: ${this.$i18n.t('setup.head').toLowerCase()}`
-    }
   }
 }
 </script>
+
+<style lang="scss" scoped>
+section.setup-panel {
+  @apply bg-gray-100 border border-gray-300 shadow-xl rounded-lg -mt-8 divide-y divide-gray-400;
+
+  & > .step {
+    @apply p-4;
+
+    & > h1 {
+      @apply text-2xl font-bold uppercase text-gray-800 mb-2;
+    }
+
+    & > .content {
+      @apply overflow-hidden scale-y-0 transform;
+
+      transition: transform 500ms ease-out;
+    }
+
+    &.active > .content {
+      @apply scale-y-100;
+    }
+
+    & > .description {
+      @apply text-black text-opacity-90 -mt-1;
+    }
+  }
+
+  div.preset-card {
+    @apply bg-gray-50 p-3 border border-gray-200 text-black cursor-pointer select-none;
+
+    h1 {
+      @apply text-lg;
+
+      & > span.title {
+        @apply font-bold uppercase;
+      }
+
+      & > span.preview {
+        @apply float-right;
+      }
+    }
+
+    & > div.description {
+      @apply text-opacity-80 text-black;
+    }
+
+    &.selected {
+      @apply bg-primary text-white shadow-md;
+
+      & > div.description {
+        @apply text-white;
+      }
+    }
+  }
+
+  .finish-button {
+    @apply bg-green-600 text-white font-bold text-lg text-center p-2 rounded-lg border border-green-700 uppercase hover:bg-green-700 cursor-pointer m-4 mt-0;
+  }
+}
+</style>

--- a/pages/timer.vue
+++ b/pages/timer.vue
@@ -65,6 +65,7 @@
 // import LazyHydrate from 'vue-lazy-hydration'
 
 export default {
+  name: 'PageTimer',
   components: {
     Ticker: () => import(/* webpackChunkName: "ticker", webpackMode: "eager" */ '@/components/ticker.vue'),
     ScheduleDisplay: () => import(/* webpackChunkName: "schedule", webpackPrefetch: true */ '@/components/schedule/scheduleDisplay.vue'),

--- a/pages/timer.vue
+++ b/pages/timer.vue
@@ -1,5 +1,8 @@
 <template>
   <section class="timer-section" :style="{'background-color': $store.getters['schedule/currentScheduleColour']}">
+    <!-- Dark mode background override -->
+    <div class="absolute w-full h-full dark:bg-gray-900" />
+
     <!-- Settings button -->
     <ui-button subtle class="absolute" style="top: 0.5rem; right: 0.5rem; z-index: 10;" @click="showSettings = true">
       <client-only>
@@ -162,6 +165,8 @@ html {
 }
 
 section.timer-section {
+  @apply dark:text-gray-50;
+
   height: 100vh;
   transition: background-color 300ms ease-in;
 }

--- a/pages/timer.vue
+++ b/pages/timer.vue
@@ -93,6 +93,10 @@ export default {
   head () {
     return {
       title: `(${this.remainingTimeString}) ${this.pageTitle}`,
+      meta: [{
+        hid: 'description',
+        content: 'Jumpstart your Pomodoro sessions with the timer of AnotherPomodoro.'
+      }],
       link: [
         {
           rel: 'icon',

--- a/pages/timer.vue
+++ b/pages/timer.vue
@@ -37,9 +37,10 @@
           </lazy-hydrate>
 
           <lazy-hydrate when-visible>
-            <transition name="transition-fade">
+            <transition name="progress-transition">
               <timer-progress
                 v-if="$store.getters['settings/performanceSettings'].showProgressBar"
+                :key="$store.getters['schedule/getCurrentItem'].id"
                 :time-elapsed="timeElapsed"
                 :time-original="timeOriginal"
               />
@@ -166,10 +167,10 @@ html {
 }
 
 section.timer-section {
-  @apply dark:text-gray-50;
+  @apply dark:text-gray-50 transition-colors duration-300 ease-in;
 
   height: 100vh;
-  transition: background-color 300ms ease-in;
+  // transition: background-color 300ms ease-in;
 }
 
 .timer-background {
@@ -188,5 +189,22 @@ section.timer-section {
 .schedule-transition-leave-to {
   transform: translateY(-20px);
   opacity: 0;
+}
+
+.progress-transition-enter-active,
+.progress-transition-leave-active {
+  transition: 500ms ease-in;
+  transition-property: transform !important;
+}
+
+// .progress-transition-enter {
+// }
+
+.progress-transition-leave-to {
+  transform: translateX(0%) !important;
+}
+
+.dark .progress-transition-leave-to {
+  transform: translateX(-100%) !important;
 }
 </style>

--- a/plugins/vuex-persist.client.js
+++ b/plugins/vuex-persist.client.js
@@ -5,6 +5,9 @@ export default function ({ store }) {
   new VuexPersistence({
     key: 'user-settings',
     storage: window.localStorage,
-    paths: ['settings', 'tasklist']
+    paths: ['settings', 'tasklist'],
+    rehydrated: (store) => {
+      store.commit('loading/finished')
+    }
   })(store)
 }

--- a/store/loading.js
+++ b/store/loading.js
@@ -1,0 +1,13 @@
+export default {
+  state () {
+    return {
+      persist_finished: false
+    }
+  },
+
+  mutations: {
+    finished (state) {
+      state.persist_finished = true
+    }
+  }
+}

--- a/store/settings.js
+++ b/store/settings.js
@@ -32,7 +32,8 @@ export const state = () => ({
     },
     wait: {
       colour: 'rgb(222, 226, 230)'
-    }
+    },
+    darkMode: false
   },
   performance: {
     showProgressBar: true

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ module.exports = {
     './plugins/**/*.{js,ts}',
     './nuxt.config.{js,ts}'
   ],
-  darkMode: false,
+  darkMode: 'class',
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
### Features

* Add dark mode ([#97](https://github.com/Hanziness/AnotherPomodoro/issues/97)) ([3da8e41](https://github.com/Hanziness/AnotherPomodoro/commit/3da8e41bc7eae02e923abcbbb2a5fb77e13cd572))
* **seo:** Add meta descriptions to the setup and timer pages ([a5a506b](https://github.com/Hanziness/AnotherPomodoro/commit/a5a506b55d4685382fcefe3af1ca5f785b432f19))


### Bug Fixes

* Fix Vue warnings related to component names ([0497ec8](https://github.com/Hanziness/AnotherPomodoro/commit/0497ec885a15cbd0f965df43c993e28e4a1090bc))
* Improve progress bar behaviour on skip ([8e8f12a](https://github.com/Hanziness/AnotherPomodoro/commit/8e8f12abe2616710f00b7e8a387f4eb408b2e369))
* Language should now be permanent across pages ([9fad494](https://github.com/Hanziness/AnotherPomodoro/commit/9fad494b2ac41e8f7aad7cdfb5c36c2678b924b2))


### Refactors

* Fix `vue/component-tag-order` warnings ([#98](https://github.com/Hanziness/AnotherPomodoro/issues/98)) ([96a9c10](https://github.com/Hanziness/AnotherPomodoro/commit/96a9c109357e954f5f832e404358c54f565aac6c))

