### PR TITLE
refactor: Replace Material Design icons with Tabler Icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The app itself still does not collect any data (eg. when you're running it on yo
   * [`@aceforth/nuxt-optimized-images`](https://marquez.co/docs/nuxt-optimized-images) for automatic build-time image optimization
 * [**Tailwind CSS**](https://tailwindcss.com/)
   * [`@tailwindcss/forms`](https://github.com/tailwindlabs/tailwindcss-forms)
-* [Material Design Icons](https://materialdesignicons.com/) through [`vue-material-design-icons`](https://github.com/robcresswell/vue-material-design-icons)
+* [Tabler Icons](https://tabler-icons.io/) through [`vue-tabler-icons`](https://github.com/alex-oleshkevich/vue-tabler-icons)
 * [DayJS](https://day.js.org/) for time formatting
 * [`conventional-changelog/standard-version`](https://github.com/conventional-changelog/standard-version) for automatic changelog generation from [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
 

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -44,7 +44,7 @@
               <div :class="['reset-button', { 'active': resetConfirm }]" role="button" @click="resetConfirm = true">
                 <span>
                   <span v-text="$i18n.t('settings.reset.title')" />
-                  <span class="float-right"><reset-icon :size="28" /></span>
+                  <span class="float-right"><reset-icon size="28" /></span>
                 </span>
                 <transition name="transition-fade">
                   <div v-if="resetConfirm" class="left-0 top-0 absolute w-full h-full grid grid-flow-col grid-cols-2 items-stretch">
@@ -109,7 +109,7 @@
 </template>
 
 <script>
-import ResetIcon from 'vue-material-design-icons/AlertCircle.vue'
+import { RefreshAlertIcon, XIcon } from 'vue-tabler-icons'
 import { timerPresets } from '@/store/settings'
 
 export default {
@@ -122,8 +122,8 @@ export default {
     SettingsTime: () => import(/* webpackMode: "eager" */ '@/components/settings/items/settingsTime.vue'),
     SettingsOptions: () => import(/* webpackMode: "eager" */ '@/components/settings/items/settingsOptions.vue'),
     Divider: () => import(/* webpackMode: "eager" */ '@/components/base/divider.vue'),
-    CloseIcon: () => import(/* webpackMode: "eager" */ 'vue-material-design-icons/Close.vue'),
-    ResetIcon
+    CloseIcon: XIcon,
+    ResetIcon: RefreshAlertIcon
   },
   props: {
     value: {

--- a/components/timer/controls/basic.vue
+++ b/components/timer/controls/basic.vue
@@ -7,7 +7,7 @@
       @click="reset"
     >
       <div>
-        <icon-stop :size="24" :title="$i18n.t('controls.stop')" />
+        <icon-stop size="24" :title="$i18n.t('controls.stop')" />
       </div>
     </div>
 
@@ -22,10 +22,10 @@
     >
       <transition name="transition-fade" mode="out-in" tag="div" class="">
         <div v-if="$store.getters['schedule/getCurrentTimerState'] !== 1" :key="1" class="relative">
-          <icon-play :size="64" :title="$i18n.t('controls.start')" />
+          <icon-play size="64" stroke-width="1" :title="$i18n.t('controls.start')" />
         </div>
         <div v-else :key="2" class="relative">
-          <icon-pause :size="64" :title="$i18n.t('controls.pause')" />
+          <icon-pause size="64" stroke-width="1" :title="$i18n.t('controls.pause')" />
         </div>
       </transition>
     </div>
@@ -37,17 +37,14 @@
       @click="advance"
     >
       <div>
-        <icon-skip-next :size="24" :title="$i18n.t('controls.next')" />
+        <icon-skip-next size="24" :title="$i18n.t('controls.next')" />
       </div>
     </div>
   </div>
 </template>
 
 <script>
-import IconPlay from 'vue-material-design-icons/Play.vue'
-import IconPause from 'vue-material-design-icons/Pause.vue'
-import IconStop from 'vue-material-design-icons/Stop.vue'
-import IconSkipNext from 'vue-material-design-icons/SkipNext.vue'
+import { PlayerPlayIcon, PlayerPauseIcon, PlayerStopIcon, PlayerSkipForwardIcon } from 'vue-tabler-icons'
 import KeyboardListener from '@/assets/mixins/keyboardListener'
 
 import { TimerState } from '@/store/schedule'
@@ -55,10 +52,10 @@ import { TimerState } from '@/store/schedule'
 export default {
   components: {
     // UiButton: () => import(/* webpackChunkName: "uibase" */ '@/components/base/button.vue'),
-    IconPlay,
-    IconPause,
-    IconStop,
-    IconSkipNext
+    IconPlay: PlayerPlayIcon,
+    IconPause: PlayerPauseIcon,
+    IconStop: PlayerStopIcon,
+    IconSkipNext: PlayerSkipForwardIcon
   },
 
   mixins: [KeyboardListener],

--- a/components/timer/display/timerComplete.vue
+++ b/components/timer/display/timerComplete.vue
@@ -5,10 +5,10 @@
 </template>
 
 <script>
-import CompleteIcon from 'vue-material-design-icons/Check.vue'
+import { CheckIcon } from 'vue-tabler-icons'
 
 export default {
-  components: { CompleteIcon }
+  components: { CompleteIcon: CheckIcon }
 }
 </script>
 

--- a/components/todoList/addTask.vue
+++ b/components/todoList/addTask.vue
@@ -2,17 +2,17 @@
   <div class="flex flex-row space-x-2 rounded-xl bg-gray-100 py-4 pl-4 pr-2 focus-within:bg-white focus-within:shadow-lg shadow-sm transition-all duration-500 focus-within:duration-200 items-center" :style="{ '--theme': $store.getters['schedule/currentScheduleColour'] }">
     <input v-model="taskTitle" type="text" required class="block min-w-0 bg-transparent border-none rounded-full focus:ring-transparent peer flex-grow p-0" @keyup="checkEnter">
     <button :class="['rounded-lg bg-theme bg-opacity-80 hover:bg-opacity-100 text-white px-3 py-2 -my-3 transition-all', { 'bg-gray-200 opacity-60 pointer-events-none': !valid }]" @click="addTask">
-      <IconReturn />
+      <CornerDownLeftIcon size="24" />
     </button>
   </div>
 </template>
 
 <script>
-import IconReturn from 'vue-material-design-icons/KeyboardReturn.vue'
+import { CornerDownLeftIcon } from 'vue-tabler-icons'
 import { taskState } from '@/store/tasklist.js'
 
 export default {
-  components: { IconReturn },
+  components: { CornerDownLeftIcon },
 
   data () {
     return {

--- a/components/todoList/item.vue
+++ b/components/todoList/item.vue
@@ -12,7 +12,7 @@
   >
     <div :class="['-ml-2 -my-2 mr-2 self-stretch themed-bg transition-all duration-75 text-white flex flex-row items-center', { 'w-0': !showReorder, 'w-6': showReorder }]">
       <span v-show="showReorder">
-        <IconMenu :size="16" />
+        <IconMenu size="16" />
       </span>
     </div>
     <div class="flex flex-col select-none">
@@ -22,7 +22,7 @@
     <span class="flex-grow" />
     <transition name="slidein">
       <button v-show="manage" class="transition-all duration-100" @click="$emit('delete')">
-        <IconDelete :size="18" />
+        <IconDelete size="18" class="mr-1" />
       </button>
     </transition>
     <span><input :checked="checked" type="checkbox" class="rounded w-5 h-5 mr-1 themed-checkbox" @input="checked = !checked"></span>
@@ -30,12 +30,11 @@
 </template>
 
 <script>
-import IconMenu from 'vue-material-design-icons/Menu.vue'
-import IconDelete from 'vue-material-design-icons/TrashCan.vue'
+import { MenuIcon, EraserIcon } from 'vue-tabler-icons'
 import { taskState } from '@/store/tasklist'
 
 export default {
-  components: { IconMenu, IconDelete },
+  components: { IconMenu: MenuIcon, IconDelete: EraserIcon },
   props: {
     item: {
       type: Object,

--- a/components/todoList/main.vue
+++ b/components/todoList/main.vue
@@ -3,7 +3,9 @@
     <div class="flex flex-row items-center">
       <p class="uppercase text-xl text-gray-800 font-bold tracking-tighter" v-text="$i18n.t('tasks.title')" />
       <div class="flex-grow" />
-      <button v-show="!$store.getters['schedule/isRunning']" :class="['px-2 py-1 text-xs rounded-lg border border-yellow-300 bg-yellow-100 text-yellow-800 transition-colors', { 'bg-yellow-200': manageMode }]" @click="manageMode = !manageMode" v-text="$i18n.t('tasks.manage')" />
+      <button v-show="!$store.getters['schedule/isRunning']" :class="['px-2 py-1 text-xs rounded-lg border border-yellow-300 bg-yellow-100 text-yellow-800 transition-colors', { 'bg-yellow-200': manageMode }]" @click="manageMode = !manageMode">
+        <span><IconManage class="inline translate-y-[-0.1rem]" size="16" /> {{ $i18n.t('tasks.manage') }}</span>
+      </button>
     </div>
     <div v-show="displayedTasks.length < 1" key="notask" class="italic text-black text-opacity-70 mt-3" v-text="$i18n.t('tasks.empty')" />
     <transition-group
@@ -30,11 +32,12 @@
 </template>
 
 <script>
+import { EditIcon } from 'vue-tabler-icons'
 import TaskItem from '@/components/todoList/item.vue'
 import TaskAdd from '@/components/todoList/addTask.vue'
 
 export default {
-  components: { TaskItem, TaskAdd },
+  components: { TaskItem, TaskAdd, IconManage: EditIcon },
   data () {
     return {
       manageMode: false,

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "nuxt-edge": "latest",
     "sass-loader": "^10.0.4",
     "vue-lazy-hydration": "^2.0.0-beta.4",
-    "vue-material-design-icons": "^4.10.0",
     "vue-native-notification": "^1.1.1",
+    "vue-tabler-icons": "^1.0",
     "vuelidate": "^0.7.5",
     "vuex": "^3.6.2",
     "vuex-persistedstate": "^3.0.0"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -123,7 +123,7 @@
         <client-only>
           <a href="https://github.com/Hanziness/AnotherPomodoro" class="relative hint-left" rel="noopener" :aria-label="$i18n.t('index.section_05.support.github')">
             <div class="support-icon text-white bg-gray-900">
-              <icon-github :size="42" title="" />
+              <icon-github size="42" title="" />
             </div>
           </a>
           <a href="https://www.buymeacoffee.com/imreg" class="relative hint-right" rel="noopener" :aria-label="$i18n.t('index.section_05.support.buymeacoffee')">
@@ -140,16 +140,16 @@
 </template>
 
 <script>
-import IconLightBulb from 'vue-material-design-icons/LightbulbOn.vue'
-import IconCheck from 'vue-material-design-icons/CheckBold.vue'
-import IconHand from 'vue-material-design-icons/Handshake.vue'
-import IconGithub from 'vue-material-design-icons/Github.vue'
-import IconRepeat from 'vue-material-design-icons/Repeat.vue'
+import { BulbIcon, CheckIcon, HeartIcon, BrandGithubIcon, RepeatIcon } from 'vue-tabler-icons'
 
 export default {
   name: 'PageIndex',
   components: {
-    IconLightBulb, IconCheck, IconHand, IconGithub, IconRepeat
+    IconLightBulb: BulbIcon,
+    IconCheck: CheckIcon,
+    IconOpenSource: HeartIcon,
+    IconGithub: BrandGithubIcon,
+    IconRepeat: RepeatIcon
   },
 
   data () {
@@ -159,7 +159,7 @@ export default {
       features: [
         { icon: 'IconLightBulb', iconClass: 'text-yellow-500' },
         { icon: 'IconCheck', iconClass: 'text-green-600' },
-        { icon: 'IconHand', iconClass: 'text-blue-600' }
+        { icon: 'IconOpenSource', iconClass: 'text-red-600' }
       ],
       scheduleCards: [
         { bg: 'bg-red-100', border: 'border-red-400', info: true },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -123,7 +123,7 @@
         <client-only>
           <a href="https://github.com/Hanziness/AnotherPomodoro" class="relative hint-left" rel="noopener" :aria-label="$i18n.t('index.section_05.support.github')">
             <div class="support-icon text-white bg-gray-900">
-              <icon-github size="42" title="" />
+              <icon-github class="m-[3px]" size="36" title="" />
             </div>
           </a>
           <a href="https://www.buymeacoffee.com/imreg" class="relative hint-right" rel="noopener" :aria-label="$i18n.t('index.section_05.support.buymeacoffee')">

--- a/pages/timer.vue
+++ b/pages/timer.vue
@@ -64,6 +64,7 @@
 
 <script>
 // import LazyHydrate from 'vue-lazy-hydration'
+import { SettingsIcon } from 'vue-tabler-icons'
 
 export default {
   name: 'PageTimer',
@@ -78,7 +79,7 @@ export default {
     SettingsPanel: () => import(/* webpackChunkName: "settings", webpackMode: "eager" */ '@/components/settings/settingsPanel.vue'),
     UiButton: () => import(/* webpackChunkName: "uibase", webpackPrefetch: true */ '@/components/base/button.vue'),
     UiOverlay: () => import(/* webpackChunkName: "uibase", webpackPrefetch: true */ '@/components/base/overlay.vue'),
-    CogIcon: () => import(/* webpackChunkName: "icons", webpackMode: "eager" */ 'vue-material-design-icons/Cog.vue'),
+    CogIcon: SettingsIcon,
     LazyHydrate: () => import(/* webpackMode: "eager" */ 'vue-lazy-hydration'),
     TodoList: () => import('@/components/todoList/main.vue')
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13951,11 +13951,6 @@ vue-loader@^15.9.8:
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
 
-vue-material-design-icons@^4.10.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/vue-material-design-icons/-/vue-material-design-icons-4.13.0.tgz#8bab3335c4f906799493d5de52dafed853daa186"
-  integrity sha512-TwaWrvh4J49VdkV9Uzcbr/p3FBRiBthRkIrg6SUh7ogFUljdA2ySNoAYD9dTU+mJkANIn1A6MoD/PnyLONnkWg==
-
 vue-meta@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/vue-meta/-/vue-meta-2.4.0.tgz#a419fb4b4135ce965dab32ec641d1989c2ee4845"
@@ -13999,6 +13994,11 @@ vue-style-loader@^4.1.0, vue-style-loader@^4.1.3:
   dependencies:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
+
+vue-tabler-icons@^1.0:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/vue-tabler-icons/-/vue-tabler-icons-1.12.1.tgz#3865c7b641cc7f755619533d94530fbefb2e07eb"
+  integrity sha512-hWojgXOfk6ZHBSC8t38ZIuIT1fyrpC9V5+cn7lzTH84xKHBnXU7PaNr7xHoL4Xy3JFlhA9AgCNpW16/QuAk9aA==
 
 vue-template-compiler@^2.6.14:
   version "2.6.14"


### PR DESCRIPTION
Switches iconography from Material Design Icons to Tabler Icons. These icons are a bit more rounded and their thickness can be adjusted, so they better fit the new design of the app.

Closes #110 