### PR TITLE
feat(settings): Revamp settings panel

### DIFF
--- a/components/base/inputText.vue
+++ b/components/base/inputText.vue
@@ -1,7 +1,7 @@
 <template>
   <input
     v-model="displayValue"
-    class="form-input w-full text-right"
+    :class="['form-input w-full text-right', { 'ring-yellow-600 focus:ring-yellow-600': $v.internalData.$anyError }]"
     type="text"
   >
 </template>
@@ -50,7 +50,7 @@ export default {
     return {
       /** Internal v-model value (can contain invalid input, unlike the setting
        * value that it corresponds to) */
-      internalData: null,
+      internalData: this.value,
 
       /** Controls whether the input is invalid or not */
       dirty: true
@@ -81,18 +81,11 @@ export default {
      */
     displayValue: {
       get () {
-        if (!this.dirty) {
-          return this.internalData
-        } else {
-          return this.value
-        }
+        return this.internalData
       },
 
       set (newValue) {
         this.internalData = newValue
-
-        // Check if the value needs to be numeric (if so, cast it)
-        if (this.numeric) { this.internalData = Number.parseInt(this.internalData) }
 
         // Force validation
         this.$v.internalData.$touch()

--- a/components/settings/baseSettingsItemBare.vue
+++ b/components/settings/baseSettingsItemBare.vue
@@ -1,5 +1,5 @@
 <template>
-  <section v-show="visible" :class="[{'disabled': disabled}]" :disabled="disabled" :aria-disabled="disabled">
+  <section v-show="visible" :class="['transition-all -m-1 p-1 rounded-lg', { 'disabled': disabled, 'ring ring-yellow-200 bg-yellow-100': isError }]" :disabled="disabled" :aria-disabled="disabled">
     <div class="flex flex-row items-center" :class="[(!showDescription || !!$slots['content-main']) ? 'h-10' : 'h-12']">
       <div v-if="!!$slots['icon']" class="w-12 text-left">
         <slot name="icon" />
@@ -16,11 +16,6 @@
           </slot>
         </div>
       </div>
-      <slot name="content-error" :errorValue="errorValue">
-        <div v-show="errorValue && errorValue.length > 0" class="bg-red-700 text-white text-sm rounded px-2 mx-2">
-          {{ errorValue }}
-        </div>
-      </slot>
       <div class="w-24 text-right">
         <!-- v-if="!!$slots['content-action']"  -->
         <slot name="content-action" :settingsValue="settingsValue" :errorValue="errorValue" />
@@ -31,11 +26,22 @@
     <div class="">
       <slot name="content-main" :settingsValue="settingsValue" />
     </div>
+    <slot name="content-error" :errorValue="errorValue">
+      <div v-show="isError" class="mt-1 text-yellow-700 flex flex-row space-x-1 items-center">
+        <ErrorIcon />
+        <span v-text="errorValue" />
+      </div>
+    </slot>
   </section>
 </template>
 
 <script>
+import { AlertTriangleIcon } from 'vue-tabler-icons'
+
 export default {
+  components: {
+    ErrorIcon: AlertTriangleIcon
+  },
   props: {
     /** Whether to show the description of the setting */
     showDescription: {
@@ -82,6 +88,11 @@ export default {
   data () {
     return {
       isInputValid: true
+    }
+  },
+  computed: {
+    isError () {
+      return this.errorValue && this.errorValue.length > 0
     }
   }
 }

--- a/components/settings/items/settingsText.vue
+++ b/components/settings/items/settingsText.vue
@@ -7,6 +7,7 @@
         :min="min"
         :max="max"
         :numeric="numeric"
+        required
         @input="update($event)"
         @error="error($event.type, $event.additionalInfo)"
       />
@@ -16,9 +17,8 @@
 
 <script>
 import { validationMixin } from 'vuelidate'
-import settingsInputMixin from '@/assets/mixins/settings/settingsItemBase'
-
 import { required, minValue, maxValue, numeric } from 'vuelidate/lib/validators'
+import settingsInputMixin from '@/assets/mixins/settings/settingsItemBase'
 
 export default {
   components: {

--- a/components/settings/items/settingsTime.vue
+++ b/components/settings/items/settingsTime.vue
@@ -3,7 +3,7 @@
     <template #content-action="{ settingsValue, update, error }">
       <input-text
         :value="msToTimeStr(settingsValue)"
-        :custom-validators="{ 'time_format': timeRule }"
+        :custom-validators="{ 'time_format': timeRule, 'min_time': minTimeRule }"
         @input="update(timeStrToMs($event))"
         @error="error($event.type, $event.additionalInfo)"
       />
@@ -67,6 +67,15 @@ export default {
       return secondPartAsNumber >= 0 && secondPartAsNumber <= 59
     },
 
+    minTimeRule (valueString) {
+      if (!this.timeRule(valueString)) {
+        return false
+      }
+
+      const timeInMs = this.timeStrToMs(valueString)
+      return timeInMs >= this.minMs
+    },
+
     timeStrToMs (valueString) {
       if (typeof valueString !== 'string' || !this.timeRule(valueString)) { return null }
 
@@ -89,16 +98,16 @@ export default {
       let pass = true
 
       // check if value is above minimum
-      // if (this.minMs && valueInMs < this.minMs) {
-      //   errorFn(Error.ERR_MIN, errorAdditionalInfo)
-      //   return
-      // }
+      if (this.minMs && valueInMs < this.minMs) {
+        errorFn(Error.ERR_MIN, errorAdditionalInfo)
+        return
+      }
 
-      // // check if value is below maximum
-      // if (this.maxMs && valueInMs > this.maxMs) {
-      //   errorFn(Error.ERR_MAX, errorAdditionalInfo)
-      //   return
-      // }
+      // check if value is below maximum
+      if (this.maxMs && valueInMs > this.maxMs) {
+        errorFn(Error.ERR_MAX, errorAdditionalInfo)
+        return
+      }
 
       for (const rule in this.rules) {
         const rulePass = rule(valueInMs)

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -83,6 +83,43 @@
               <settings-check :settings-key="['pageTitle', 'useTickEmoji']" />
               <!-- TODO Audio volume control -->
             </div>
+            <div v-if="activeTab === 4" :key="4" class="settings-tab">
+              <div class="flex flex-col items-center">
+                <img src="/favicon.png" width="64" height="64" class="inline-block bg-red-200 rounded-lg p-2 mb-1">
+                <div>
+                  <div class="font-bold text-2xl inline-block">
+                    AnotherPomodoro
+                  </div>
+                  <sup class="text-base" v-text="$store.state.version" />
+                </div>
+                <div v-text="$i18n.t('settings.about.madeby')" />
+                <div class="mt-8 flex flex-col justify-center items-center">
+                  <!-- Support links -->
+                  <div class="mt-3 flex flex-row space-x-2">
+                    <a href="https://www.github.com/Hanziness/AnotherPomodoro?utm_source=AnotherPomodoro&utm_medium=web&utm_content=settings" class="rounded-full bg-black hover:bg-gray-700 active:bg-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600 dark:active:bg-gray-800 text-white flex flex-row items-center px-3 py-2 space-x-1 transition-colors">
+                      <AboutGithub />
+                      <span v-text="$i18n.t('settings.about.source')" />
+                    </a>
+                    <a href="https://www.buymeacoffee.com/imreg?utm_source=AnotherPomodoro&utm_medium=web&utm_content=settings" class="rounded-full bg-yellow-300 hover:bg-yellow-200 active:bg-yellow-400 text-black flex flex-row items-center px-3 py-2 space-x-1 transition-colors">
+                      <AboutSupport />
+                      <span v-text="$i18n.t('settings.about.support')" />
+                    </a>
+                  </div>
+                  <!-- Share links -->
+                  <div class="my-2" v-text="$i18n.t('settings.about.share')" />
+                  <div class="flex flex-row items-center space-x-2 text-sm">
+                    <a href="https://twitter.com/AnotherPomodoro?utm_source=AnotherPomodoro&utm_medium=web&utm_content=settings" class="rounded-full w-12 h-12 bg-[#1da1f2] text-white flex flex-row items-center justify-center space-x-1 transition-colors">
+                      <AboutTwitter size="24" />
+                    <!-- <span>@AnotherPomodoro</span> -->
+                    </a>
+                    <a href="http://www.facebook.com/share.php?u=https://another-pomodoro.netlify.com" class="rounded-full w-12 h-12 bg-[#1877f2] text-white flex flex-row items-center justify-center space-x-1 transition-colors">
+                      <AboutFacebook size="24" class="translate-x-[-1px]" />
+                    <!-- <span>@AnotherPomodoro</span> -->
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
           </transition>
         </div>
       </div>
@@ -97,13 +134,16 @@
         <div class="tab-header" :class="[{'active': activeTab === 3}]" @click="activeTab = 3">
           <TabIconVisuals /> <span>{{ $i18n.t('settings.tabs.display') }}</span>
         </div>
+        <div class="tab-header" :class="[{'active': activeTab === 4}]" @click="activeTab = 4">
+          <TabIconAbout /> <span>{{ $i18n.t('settings.tabs.about') }}</span>
+        </div>
       </div>
     </div>
   </section>
 </template>
 
 <script>
-import { XIcon, AdjustmentsIcon, AlarmIcon, ArtboardIcon, InfoCircleIcon } from 'vue-tabler-icons'
+import { XIcon, AdjustmentsIcon, AlarmIcon, ArtboardIcon, InfoCircleIcon, BrandGithubIcon, CoffeeIcon, BrandTwitterIcon, BrandFacebookIcon } from 'vue-tabler-icons'
 import { timerPresets } from '@/store/settings'
 
 export default {
@@ -121,7 +161,12 @@ export default {
     TabIconGeneral: AdjustmentsIcon,
     TabIconSchedule: AlarmIcon,
     TabIconVisuals: ArtboardIcon,
-    InfoIcon: InfoCircleIcon
+    TabIconAbout: InfoCircleIcon,
+    InfoIcon: InfoCircleIcon,
+    AboutGithub: BrandGithubIcon,
+    AboutSupport: CoffeeIcon,
+    AboutTwitter: BrandTwitterIcon,
+    AboutFacebook: BrandFacebookIcon
   },
   props: {
     value: {

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -268,7 +268,7 @@ div.settings-tab {
 }
 
 .tab-transition-leave-to {
-  transform: translateY(10px);
+  transform: translateY(-10px);
   opacity: 0;
 }
 

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -41,18 +41,7 @@
 
               <divider />
 
-              <div :class="['reset-button', { 'active': resetConfirm }]" role="button" @click="resetConfirm = true">
-                <span>
-                  <span v-text="$i18n.t('settings.reset.title')" />
-                  <span class="float-right"><reset-icon size="28" /></span>
-                </span>
-                <transition name="transition-fade">
-                  <div v-if="resetConfirm" class="left-0 top-0 absolute w-full h-full grid grid-flow-col grid-cols-2 items-stretch">
-                    <div class="reset-subbutton" @click.stop="triggerSettingsReset" v-text="$i18n.t('settings.reset.confirm')" />
-                    <div class="reset-subbutton" @click.stop="resetConfirm = false" v-text="$i18n.t('settings.reset.cancel')" />
-                  </div>
-                </transition>
-              </div>
+              <settings-check :settings-key="['reset']" />
             </div>
 
             <div v-if="activeTab === 2" :key="2" class="settings-tab">
@@ -109,7 +98,7 @@
 </template>
 
 <script>
-import { RefreshAlertIcon, XIcon, AdjustmentsIcon, AlarmIcon, ArtboardIcon } from 'vue-tabler-icons'
+import { XIcon, AdjustmentsIcon, AlarmIcon, ArtboardIcon } from 'vue-tabler-icons'
 import { timerPresets } from '@/store/settings'
 
 export default {
@@ -123,7 +112,7 @@ export default {
     SettingsOptions: () => import(/* webpackMode: "eager" */ '@/components/settings/items/settingsOptions.vue'),
     Divider: () => import(/* webpackMode: "eager" */ '@/components/base/divider.vue'),
     CloseIcon: XIcon,
-    ResetIcon: RefreshAlertIcon,
+    // ResetIcon: RefreshAlertIcon,
     TabIconGeneral: AdjustmentsIcon,
     TabIconSchedule: AlarmIcon,
     TabIconVisuals: ArtboardIcon

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -110,11 +110,12 @@
                   <div class="flex flex-row items-center space-x-2 text-sm">
                     <a href="https://twitter.com/AnotherPomodoro?utm_source=AnotherPomodoro&utm_medium=web&utm_content=settings" class="rounded-full w-12 h-12 bg-[#1da1f2] text-white flex flex-row items-center justify-center space-x-1 transition-colors">
                       <AboutTwitter size="24" />
-                    <!-- <span>@AnotherPomodoro</span> -->
                     </a>
-                    <a href="http://www.facebook.com/share.php?u=https://another-pomodoro.netlify.com" class="rounded-full w-12 h-12 bg-[#1877f2] text-white flex flex-row items-center justify-center space-x-1 transition-colors">
+                    <a href="http://www.facebook.com/share.php?u=https://another-pomodoro.netlify.app" class="rounded-full w-12 h-12 bg-[#1877f2] text-white flex flex-row items-center justify-center space-x-1 transition-colors">
                       <AboutFacebook size="24" class="translate-x-[-1px]" />
-                    <!-- <span>@AnotherPomodoro</span> -->
+                    </a>
+                    <a href="https://reddit.com/submit?url=https://another-pomodoro.netlify.app" class="rounded-full w-12 h-12 bg-[#ff4500] text-white flex flex-row items-center justify-center space-x-1 transition-colors">
+                      <AboutReddit size="24" />
                     </a>
                   </div>
                 </div>
@@ -143,7 +144,7 @@
 </template>
 
 <script>
-import { XIcon, AdjustmentsIcon, AlarmIcon, ArtboardIcon, InfoCircleIcon, BrandGithubIcon, CoffeeIcon, BrandTwitterIcon, BrandFacebookIcon } from 'vue-tabler-icons'
+import { XIcon, AdjustmentsIcon, AlarmIcon, ArtboardIcon, InfoCircleIcon, BrandGithubIcon, CoffeeIcon, BrandTwitterIcon, BrandFacebookIcon, BrandRedditIcon } from 'vue-tabler-icons'
 import { timerPresets } from '@/store/settings'
 
 export default {
@@ -166,7 +167,8 @@ export default {
     AboutGithub: BrandGithubIcon,
     AboutSupport: CoffeeIcon,
     AboutTwitter: BrandTwitterIcon,
-    AboutFacebook: BrandFacebookIcon
+    AboutFacebook: BrandFacebookIcon,
+    AboutReddit: BrandRedditIcon
   },
   props: {
     value: {

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -95,13 +95,13 @@
 
       <div class="settings-panel-menubar">
         <div class="tab-header" :class="[{'active': activeTab === 1}]" @click="activeTab = 1">
-          <span>{{ $i18n.t('settings.tabs.main') }}</span>
+          <TabIconGeneral /> <span>{{ $i18n.t('settings.tabs.main') }}</span>
         </div>
         <div class="tab-header" :class="[{'active': activeTab === 2}]" @click="activeTab = 2">
-          <span>{{ $i18n.t('settings.tabs.timer') }}</span>
+          <TabIconSchedule /> <span>{{ $i18n.t('settings.tabs.timer') }}</span>
         </div>
         <div class="tab-header" :class="[{'active': activeTab === 3}]" @click="activeTab = 3">
-          <span>{{ $i18n.t('settings.tabs.display') }}</span>
+          <TabIconVisuals /> <span>{{ $i18n.t('settings.tabs.display') }}</span>
         </div>
       </div>
     </div>
@@ -109,7 +109,7 @@
 </template>
 
 <script>
-import { RefreshAlertIcon, XIcon } from 'vue-tabler-icons'
+import { RefreshAlertIcon, XIcon, AdjustmentsIcon, AlarmIcon, ArtboardIcon } from 'vue-tabler-icons'
 import { timerPresets } from '@/store/settings'
 
 export default {
@@ -123,7 +123,10 @@ export default {
     SettingsOptions: () => import(/* webpackMode: "eager" */ '@/components/settings/items/settingsOptions.vue'),
     Divider: () => import(/* webpackMode: "eager" */ '@/components/base/divider.vue'),
     CloseIcon: XIcon,
-    ResetIcon: RefreshAlertIcon
+    ResetIcon: RefreshAlertIcon,
+    TabIconGeneral: AdjustmentsIcon,
+    TabIconSchedule: AlarmIcon,
+    TabIconVisuals: ArtboardIcon
   },
   props: {
     value: {
@@ -237,7 +240,7 @@ div.settings-panel-menubar {
 }
 
 div.tab-header {
-  @apply flex-1 h-full bg-gray-200 p-2 cursor-pointer text-center flex items-center justify-center select-none rounded-lg;
+  @apply flex-1 h-full bg-gray-200 p-2 cursor-pointer text-center flex flex-row space-x-1 items-center justify-center select-none rounded-lg;
   @apply dark:bg-gray-800;
 
   transition: border-color 0.2s ease-out;

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <section v-show="processedValue" class="settings-panel sm:w-full md:w-1/2 lg:w-2/5">
     <div class="settings-wrapper">
-      <h1 class="title">
+      <h1 class="px-4 text-xl mt-4 mb-2 uppercase font-bold">
         <span>{{ $i18n.t('settings.heading') }}</span>
         <ui-button subtle class="float-right -mt-2 -mr-2" @click="processedValue = false">
           <close-icon :title="$i18n.t('settings.buttons.close')" />
@@ -47,6 +47,7 @@
             <div v-if="activeTab === 2" :key="2" class="settings-tab">
               <settings-text :settings-key="['schedule', 'longPauseInterval']" :min="1" numeric />
               <divider />
+
               <settings-options
                 :settings-key="['schedule', 'lengths']"
                 :custom-value="$store.getters['settings/getActiveSchedulePreset']"
@@ -54,9 +55,13 @@
                 :set-value-on-change="false"
                 :custom-set-function="(v) => { $store.commit('settings/applyPreset', v) }"
               />
-              <settings-time :settings-key="['schedule', 'lengths', 'work']" />
-              <settings-time :settings-key="['schedule', 'lengths', 'shortpause']" />
-              <settings-time :settings-key="['schedule', 'lengths', 'longpause']" />
+              <settings-time :settings-key="['schedule', 'lengths', 'work']" :min-ms="5000" />
+              <settings-time :settings-key="['schedule', 'lengths', 'shortpause']" :min-ms="5000" />
+              <settings-time :settings-key="['schedule', 'lengths', 'longpause']" :min-ms="5000" />
+              <div class="rounded-lg ring-inset ring ring-blue-400 bg-blue-100 dark:bg-gray-700 px-3 py-4 flex flex-row items-center space-x-2">
+                <InfoIcon />
+                <span>The minimum allowed time is 5 seconds</span>
+              </div>
             </div>
 
             <div v-if="activeTab === 3" :key="3" class="settings-tab">
@@ -98,7 +103,7 @@
 </template>
 
 <script>
-import { XIcon, AdjustmentsIcon, AlarmIcon, ArtboardIcon } from 'vue-tabler-icons'
+import { XIcon, AdjustmentsIcon, AlarmIcon, ArtboardIcon, InfoCircleIcon } from 'vue-tabler-icons'
 import { timerPresets } from '@/store/settings'
 
 export default {
@@ -115,7 +120,8 @@ export default {
     // ResetIcon: RefreshAlertIcon,
     TabIconGeneral: AdjustmentsIcon,
     TabIconSchedule: AlarmIcon,
-    TabIconVisuals: ArtboardIcon
+    TabIconVisuals: ArtboardIcon,
+    InfoIcon: InfoCircleIcon
   },
   props: {
     value: {
@@ -215,13 +221,9 @@ section.settings-panel {
     @apply bg-white dark:bg-gray-900 dark:text-gray-50;
 
     div.settings-panel-main {
-      @apply px-4 flex-grow overflow-y-auto pb-2;
+      @apply px-4 flex-grow overflow-y-auto py-2;
     }
   }
-}
-
-.title {
-  @apply px-4 text-xl mt-4 mb-3 uppercase font-bold;
 }
 
 div.settings-panel-menubar {

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -58,9 +58,9 @@
               <settings-time :settings-key="['schedule', 'lengths', 'work']" :min-ms="5000" />
               <settings-time :settings-key="['schedule', 'lengths', 'shortpause']" :min-ms="5000" />
               <settings-time :settings-key="['schedule', 'lengths', 'longpause']" :min-ms="5000" />
-              <div class="rounded-lg ring-inset ring ring-blue-400 bg-blue-100 dark:bg-gray-700 px-3 py-4 flex flex-row items-center space-x-2">
+              <div class="rounded-lg ring-inset ring ring-blue-400 bg-blue-100 dark:bg-gray-700 dark:text-gray-100 px-3 py-4 flex flex-row items-center space-x-2">
                 <InfoIcon />
-                <span>The minimum allowed time is 5 seconds</span>
+                <span v-text="$i18n.t('settings.scheduleMinTime')" />
               </div>
             </div>
 

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -149,7 +149,8 @@ export default {
       main: 'Main',
       timer: 'Schedule',
       display: 'Display',
-      audio: 'Audio'
+      audio: 'Audio',
+      about: 'About'
     },
     buttons: {
       close: 'Close',
@@ -161,6 +162,12 @@ export default {
       cancel: 'Cancel'
     },
     scheduleMinTime: 'The minimum allowed time is 5 seconds',
+    about: {
+      madeby: 'Made by Imre Gera',
+      source: 'Source code',
+      support: 'Support the project',
+      share: 'or share the app on social media:'
+    },
     values: {
       lang: {
         _title: 'Language',

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -306,6 +306,10 @@ export default {
           _title: 'Enable dark mode',
           _description: 'Less bright, just as productive'
         }
+      },
+      reset: {
+        _title: 'Reset settings',
+        _description: 'All settings will be reset after the app is reloaded'
       }
     }
   },

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -338,6 +338,7 @@ export default {
     min: 'Value must be at least {min}',
     max: 'Value must be at most {max}',
     time_format: 'Incorrectly formatted time (MM:SS)',
+    min_time: 'The input time is too short',
     undefined: 'Undefined error'
   },
   tasks: {

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -160,6 +160,7 @@ export default {
       confirm: 'Reset',
       cancel: 'Cancel'
     },
+    scheduleMinTime: 'The minimum allowed time is 5 seconds',
     values: {
       lang: {
         _title: 'Language',

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -174,7 +174,7 @@ export default {
         _description: '',
         _values: {
           en: 'English',
-          hu: 'Hungarian'
+          hu: 'Magyar'
         },
         _valueDescription: {
           en: '',

--- a/i18n/hu.js
+++ b/i18n/hu.js
@@ -149,7 +149,8 @@ export default {
       main: 'Alap',
       timer: 'Órarend',
       display: 'Megjelenés',
-      audio: 'Hang'
+      audio: 'Hang',
+      about: 'Névjegy'
     },
     buttons: {
       close: 'Bezárás',
@@ -161,6 +162,12 @@ export default {
       cancel: 'Mégsem'
     },
     scheduleMinTime: 'A legrövidebb megengedett időtartam 5 másodperc',
+    about: {
+      madeby: 'Készítette: Gera Imre',
+      source: 'Forráskód',
+      support: 'Támogasd a projektet',
+      share: 'vagy oszd meg ismerőseiddel az alkalmazást:'
+    },
     values: {
       lang: {
         _title: 'Nyelv',

--- a/i18n/hu.js
+++ b/i18n/hu.js
@@ -173,7 +173,7 @@ export default {
         _title: 'Nyelv',
         _description: '',
         _values: {
-          en: 'Angol',
+          en: 'English',
           hu: 'Magyar'
         },
         _valueDescription: {

--- a/i18n/hu.js
+++ b/i18n/hu.js
@@ -160,6 +160,7 @@ export default {
       confirm: 'Visszaállítás',
       cancel: 'Mégsem'
     },
+    scheduleMinTime: 'A legrövidebb megengedett időtartam 5 másodperc',
     values: {
       lang: {
         _title: 'Nyelv',

--- a/i18n/hu.js
+++ b/i18n/hu.js
@@ -306,6 +306,10 @@ export default {
           _title: 'Sötét téma bekapcsolása',
           _description: 'Kevesebb fényerő, ugyanannyi produktivitás'
         }
+      },
+      reset: {
+        _title: 'Alaphelyzetbe állítás',
+        _description: 'Az alkalmazás újratöltése után minden beállítás vissza lesz állítva'
       }
     }
   },

--- a/i18n/hu.js
+++ b/i18n/hu.js
@@ -338,6 +338,7 @@ export default {
     min: 'Az érték legalább {min} legyen',
     max: 'Az érték legfeljebb {max} legyen',
     time_format: 'Hibásan formázott idő (PP:MM)',
+    min_time: 'A bevitt időtartam túl rövid',
     undefined: 'Ismeretlen hiba'
   },
   tasks: {

--- a/plugins/vuex-persist.client.js
+++ b/plugins/vuex-persist.client.js
@@ -6,6 +6,19 @@ export default function ({ store }) {
     key: 'user-settings',
     storage: window.localStorage,
     paths: ['settings', 'tasklist'],
+    fetchBeforeUse: false,
+    overwrite: false,
+    setState (key, state, storage) {
+      const finalSettings = {}
+      finalSettings.tasklist = state.tasklist
+
+      // if settings.reset is true-ish, do not save settings
+      if (state.settings && !state.settings.reset) {
+        finalSettings.settings = state.settings
+      }
+
+      storage.setItem(key, JSON.stringify(finalSettings))
+    },
     rehydrated: (store) => {
       store.commit('loading/finished')
     }

--- a/store/settings.js
+++ b/store/settings.js
@@ -81,7 +81,8 @@ export const state = () => ({
   },
   pageTitle: {
     useTickEmoji: true
-  }
+  },
+  reset: false
 })
 
 export const getters = {


### PR DESCRIPTION
The settings panel is now (hopefully) a bit easier to use. The following changes were implemented:

* The tab bar now has icons
* There's an "about" tab in the settings panel with social share links
* Settings are more intuitive to reset: just check the "reset settings" checkbox and reload the page
* Input validation feedback is modernised and the text boxes won't try to overwrite the user input
* Tab transitions move in the same direction, creating more of a "scroll" effect instead of the previous "bouncy" one (one tab moved down and the other came up)
* Language selector boxes are not translated, making it easier to find your native language

**Screenshot:**
![AnotherPomodoro - The revamped settings panel's about section](https://user-images.githubusercontent.com/18259108/147408164-b0ff4660-24a2-4699-9e5b-330519e62e08.png)

Closes #118 