### PR TITLE
feat(setup): Redesigned setup page

### DIFF
--- a/assets/utils/mergeDeep.js
+++ b/assets/utils/mergeDeep.js
@@ -1,0 +1,27 @@
+/**
+* Performs a deep merge of objects and returns new object. Does not modify
+* objects (immutable) and merges arrays via concatenation.
+*
+* @param {...object} objects - Objects to merge
+* @returns {object} New object with merged key/values
+*/
+export function mergeDeep (...objects) {
+  const isObject = obj => obj && typeof obj === 'object'
+
+  return objects.reduce((prev, obj) => {
+    Object.keys(obj).forEach((key) => {
+      const pVal = prev[key]
+      const oVal = obj[key]
+
+      if (Array.isArray(pVal) && Array.isArray(oVal)) {
+        prev[key] = pVal.concat(...oVal)
+      } else if (isObject(pVal) && isObject(oVal)) {
+        prev[key] = mergeDeep(pVal, oVal)
+      } else {
+        prev[key] = oVal
+      }
+    })
+
+    return prev
+  }, {})
+}

--- a/assets/utils/notifications.js
+++ b/assets/utils/notifications.js
@@ -1,0 +1,20 @@
+/** Asks for notification permissions from the browser and returns the permission value. Only
+ * asks for permissions if the current permission state is `default` (ie. the user hasn't yet been
+ * asked).
+ * @returns `null` if the Notifications API is not available (there is no `Notification` object) or
+ * the permission value (`default`, `granted` or `denied`).
+ */
+export async function getNotificationPermissions () {
+  if (!Notification) { return null }
+  if (Notification.permission !== 'default') {
+    return Notification.permission
+  }
+
+  const permission = await Notification.requestPermission().then((permission) => {
+    return permission
+  }).catch((rejectreason) => {
+    return 'denied'
+  })
+
+  return permission
+}

--- a/components/base/option.vue
+++ b/components/base/option.vue
@@ -2,12 +2,12 @@
   <button class="select-option" :class="[{ 'active': active }]" @click="$emit('click')">
     <div class="select-option-title">
       <slot name="title">
-        {{ $i18n.t(translationKey + '._values.' + translationSubkey) }}
+        {{ customTitle || $i18n.t(translationKey + '._values.' + translationSubkey) }}
       </slot>
     </div>
     <div class="select-option-description">
       <slot name="description">
-        {{ $i18n.t(translationKey + '._valueDescription.' + translationSubkey) }}
+        {{ customDescription || $i18n.t(translationKey + '._valueDescription.' + translationSubkey) }}
       </slot>
     </div>
   </button>
@@ -29,6 +29,18 @@ export default {
     active: {
       type: Boolean,
       default: false
+    },
+
+    /// Override the auto-translated title
+    customTitle: {
+      type: String,
+      default: null
+    },
+
+    /// Override the auto-translated description
+    customDescription: {
+      type: String,
+      default: null
     }
   }
 }

--- a/components/base/optionGroup.vue
+++ b/components/base/optionGroup.vue
@@ -7,6 +7,8 @@
       :active="key === selected"
       :translation-key="translationKey"
       :translation-subkey="key"
+      :custom-title="overrideText.title[key] ? overrideText.title[key] : null"
+      :custom-description="overrideText.description[key] ? overrideText.description[key] : null"
       @click="select(key)"
     />
   </div>
@@ -33,6 +35,16 @@ export default {
     selected: {
       type: String,
       default: ''
+    },
+
+    overrideText: {
+      type: Object,
+      default: () => {
+        return {
+          title: {},
+          description: {}
+        }
+      }
     }
   },
 

--- a/components/setup/step.vue
+++ b/components/setup/step.vue
@@ -1,0 +1,37 @@
+<template>
+  <div :class="['p-4', { 'bg-yellow-100 dark:bg-opacity-30': attention }]">
+    <div :class="['flex flex-row items-center mb-4', { 'text-gray-800 dark:text-gray-100': !attention, 'text-yellow-500 dark:text-yellow-300': attention }]">
+      <IconAlert v-show="attention" class="mr-1" />
+      <span class="text-2xl tracking-tight font-bold uppercase" v-text="title" />
+    </div>
+    <div v-show="description !== null" class="text-black dark:text-gray-100 text-opacity-90 -mt-4 mb-3" v-text="description" />
+    <div class="content">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script>
+import { BellRingingIcon } from 'vue-tabler-icons'
+
+export default {
+  components: {
+    IconAlert: BellRingingIcon
+  },
+
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    description: {
+      type: String,
+      default: null
+    },
+    attention: {
+      type: Boolean,
+      default: false
+    }
+  }
+}
+</script>

--- a/components/timer/controls/basic.vue
+++ b/components/timer/controls/basic.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="timer-control-panel-basic ">
+  <div class="timer-control-panel-basic text-gray-900 dark:text-gray-100">
     <div
       class="control-button text-lg z-10 lower-z prev"
       :class="[{ 'disabled': $store.getters['schedule/getCurrentTimerState'] === 0 }]"

--- a/components/timer/display/_timerSwitch.vue
+++ b/components/timer/display/_timerSwitch.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="timer-container flex flex-col justify-center text-center">
+  <div class="timer-container flex flex-col justify-center text-center text-black dark:text-gray-100">
     <transition name="timer-switch" mode="out-in">
       <complete-marker v-if="$store.getters['schedule/getCurrentTimerState'] === 3" :key="'complete'" />
       <timer-traditional v-else-if="timerWidget === 'traditional'" :key="'traditional'" v-bind="timerInfo" />

--- a/components/timer/timerProgress.vue
+++ b/components/timer/timerProgress.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="['timer-progress']"
+    :class="['timer-progress', { 'ease-out-expo': background }]"
     :style="{
       'background-color': colour ? colour : $store.getters['schedule/getScheduleColour'][scheduleEntryId],
       'transform': !background ? `translateX(${-100 + progressPercentage}%)` : 'translateX(0%)'
@@ -47,12 +47,20 @@ export default {
 <style lang="scss" scoped>
 // provides a background filling progress bar (parent needs to be position: relative)
 .timer-progress {
-  transition: background-color 200ms ease-in-out, transform 200ms ease-in-out;
+  @apply transform-gpu transition-all duration-500;
+
+  transition-timing-function: cubic-bezier(0.76, 0, 0.24, 1);
   width: 100%;
   height: 100%;
-  position: fixed;
+  position: absolute;
   display: block;
   top: 0;
   left: 0;
+
+  &.ease-out-expo {
+    @apply duration-1000;
+
+    transition-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  }
 }
 </style>

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -136,6 +136,10 @@ export default {
       theme: {
         title: 'Theme',
         description: 'Control how the app looks.'
+      },
+      tip: {
+        title: 'Tip',
+        description: 'You\'ll find all the settings by clicking on the cog icon in the top right corner.'
       }
     },
     presets: {

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -114,22 +114,68 @@ export default {
     title: 'Let\'s get you started',
     startButton: 'Let\'s go',
     steps: {
-      preset: 'Choose a preset'
+      language: {
+        title: 'Language'
+      },
+      preset: {
+        title: 'Application preset',
+        description: 'These presets enable certain functions in the app so that you can use it the way you feel comfortable.'
+      },
+      timerpreset: {
+        title: 'Timer length',
+        description: 'Choose a timer preset that you\'d like to work with.'
+      },
+      timerstyle: {
+        title: 'Timer display',
+        description: 'AnotherPomodoro supports three timer styles ranging from seconds-precision to showing only a percentage.'
+      },
+      permissions: {
+        title: 'Permissions',
+        description: 'The app can play a sound and send a notification when a timer expires.'
+      },
+      theme: {
+        title: 'Theme',
+        description: 'Control how the app looks.'
+      }
     },
     presets: {
-      traditional: {
-        title: 'Absolutely traditional',
-        description: 'Typical Pomodoro setup with 25 minutes of work, 5-minute-long pauses and 15-minute-long long breaks. Uses the classic timer.'
+      _values: {
+        minimalist: 'Minimalist',
+        default: 'Default',
+        hardcore: 'Full-fledged'
       },
-      default: {
-        title: 'Default',
-        description: 'A sensible default preset with an approximate timer.'
-      },
-      hardcore: {
-        title: 'Work don\'t look',
-        description: '1-hour cycles with 50 minutes of work and 10 minutes of pause. Uses the percentage timer so you can worry less about the time left.'
+      _valueDescription: {
+        minimalist: 'No distracting items, just a timer in the middle.',
+        default: 'The starter settings. Recommended for first time users.',
+        hardcore: 'Every feature is enabled so you can have everything in front of you.'
       }
-    }
+    },
+    timerpreset: {
+      _values: {
+        default: 'Default',
+        easy: 'Beginner',
+        advanced: 'Advanced',
+        workaholic: 'Workaholic'
+      },
+      _valueDescription: {
+        default: 'The default Pomodoro values.',
+        easy: 'For those who haven\'t yet tried the Pomodoro technique.',
+        advanced: 'Work slightly more effectively.',
+        workaholic: 'For long work sessions.'
+      },
+      description: '{brief} \n {worklength} minutes of work with {splength} minutes short and {lplength} minutes long breaks after every {lpfreq} work sessions.'
+    },
+    theme: {
+      _values: {
+        light: 'Default',
+        dark: 'Dark'
+      },
+      _valueDescription: {
+        light: 'Full of friendly colours',
+        dark: 'Less bright, just as productive'
+      }
+    },
+    preview: 'preview'
   },
   section: {
     work: 'Work',

--- a/i18n/hu.js
+++ b/i18n/hu.js
@@ -114,22 +114,68 @@ export default {
     title: 'Indulás',
     startButton: 'Hajrá',
     steps: {
-      preset: 'Válassz előbeállítást'
+      language: {
+        title: 'Nyelv'
+      },
+      preset: {
+        title: 'Előbeállítás',
+        description: 'Ezek a lehetőségek előre bekapcsolnak bizonyos funkciókat, hogy úgy használhasd az alkalmazást, ahogy kényelmes.'
+      },
+      timerpreset: {
+        title: 'Időzítők hossza',
+        description: 'Válassz egy számodra kényelmes időzítő beállítást.'
+      },
+      timerstyle: {
+        title: 'Időzítő stílusa',
+        description: 'Az AnotherPomodoro háromféle időzítő megjelenést is támogat a másodperc pontosságútól a százalékos megjelenítésig.'
+      },
+      permissions: {
+        title: 'Engedélyek',
+        description: 'Az alkalmazás képes hangot lejátszani és értesítést is küldeni egy-egy időzítő lejártakor. Válaszd ki, hogy mire van szükséged.'
+      },
+      theme: {
+        title: 'Téma',
+        description: 'Beállíthatod, hogyan nézzen ki az alkalmazás.'
+      }
     },
     presets: {
-      traditional: {
-        title: 'Abszolút hagyományos',
-        description: 'Tipikus Pomodoro időzítő 25 perc munkával, 5 perces szünetekkel és 15 perces hosszú szünettel. A klasszikus időzítőt használja.'
+      _values: {
+        minimalist: 'Minimalista',
+        default: 'Alapértelmezett',
+        hardcore: 'Maximalista'
       },
-      default: {
-        title: 'Alapértelmezett',
-        description: 'Egy alap beállítás a közelítő időzítővel.'
-      },
-      hardcore: {
-        title: 'Ne nézz, dolgozz',
-        description: 'Órás ciklusok 50 perc munkával és 10 perc szünettel. A százalékos időzítőt használja, így kevésbé kell aggódnod a hátralévő időn.'
+      _valueDescription: {
+        minimalist: 'Semmi elterelő elem, csak egy időzítő középen.',
+        default: 'Az alap beállítások. Ajánlott kezdő felhasználók számára.',
+        hardcore: 'Minden funkció bekapcsolva, így minden dolog előtted lehet.'
       }
-    }
+    },
+    timerpreset: {
+      _values: {
+        default: 'Alapértelmezett',
+        easy: 'Kezdő',
+        advanced: 'Haladó',
+        workaholic: 'Munkamániás'
+      },
+      _valueDescription: {
+        default: 'Az alap Pomodoro idők.',
+        easy: 'Azok számára, akik még nem próbálták a Pomodoro technikát.',
+        advanced: 'Dolgozz kicsit hatékonyabban.',
+        workaholic: 'Hosszú munkamenetekre.'
+      },
+      description: '{brief} \n {worklength} perc munka {splength} perces rövid szünetekkel és {lplength} perces hosszú szünettel minden {lpfreq}. munkamenet után.'
+    },
+    theme: {
+      _values: {
+        light: 'Alapértelmezett',
+        dark: 'Sötét'
+      },
+      _valueDescription: {
+        light: 'Tele barátságos színekkel',
+        dark: 'Kevesebb fényerő, ugyanannyi produktivitás'
+      }
+    },
+    preview: 'előnézet'
   },
   section: {
     work: 'Munka',

--- a/i18n/hu.js
+++ b/i18n/hu.js
@@ -136,6 +136,10 @@ export default {
       theme: {
         title: 'Téma',
         description: 'Beállíthatod, hogyan nézzen ki az alkalmazás.'
+      },
+      tip: {
+        title: 'Végezetül',
+        description: 'A jobb felső sarokban lévő fogaskerék ikonra kattintva minden beállítást megtalálsz majd.'
       }
     },
     presets: {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,7 @@
 <template>
-  <nuxt />
+  <div :class="[{ 'dark': $store.state.settings.visuals.darkMode }]">
+    <nuxt />
+  </div>
 </template>
 
 <script>

--- a/layouts/timer.vue
+++ b/layouts/timer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['page', { 'dark': darkMode }]">
+  <div :class="['w-screen, h-screen relative', { 'dark': darkMode }]">
     <nuxt />
     <!-- <portal to="footer">
       <span>&copy; {{ new Date().getFullYear() }}</span>

--- a/pages/setup.vue
+++ b/pages/setup.vue
@@ -69,7 +69,7 @@
           />
         </SetupStep>
 
-        <SetupStep title="Végezetül" description="A beállításokban (fogaskerék ikon a jobb felső sarokban) minden beállítást megtalálsz majd." />
+        <SetupStep :title="$i18n.t('setup.steps.tip.title')" :description="$i18n.t('setup.steps.tip.description')" />
 
         <a href="/timer" :class="['bg-green-600 text-white font-bold text-lg text-center p-2 rounded-lg border border-green-700 uppercase hover:bg-green-700 cursor-pointer m-4 mt-0 flex flex-row items-center justify-center space-x-1', { 'opacity-60 pointer-events-none': completedSteps < 4 }]" role="button">
           <ReadyIcon />

--- a/pages/setup.vue
+++ b/pages/setup.vue
@@ -69,6 +69,8 @@
           />
         </SetupStep>
 
+        <SetupStep title="Végezetül" description="A beállításokban (fogaskerék ikon a jobb felső sarokban) minden beállítást megtalálsz majd." />
+
         <a href="/timer" :class="['bg-green-600 text-white font-bold text-lg text-center p-2 rounded-lg border border-green-700 uppercase hover:bg-green-700 cursor-pointer m-4 mt-0 flex flex-row items-center justify-center space-x-1', { 'opacity-60 pointer-events-none': completedSteps < 4 }]" role="button">
           <ReadyIcon />
           <span v-text="$i18n.t('setup.startButton')" />
@@ -76,8 +78,8 @@
       </div>
 
       <!-- Column 2: timer preview -->
-      <div class="sticky top-1 rounded-lg w-full h-[420px] overflow-hidden shadow-lg pointer-events-none">
-        <TimerPage preview />
+      <div class="sticky top-1 rounded-lg w-full h-[420px] overflow-hidden shadow-lg">
+        <TimerPage class="pointer-events-none" preview />
         <div class="absolute top-2 left-2 flex flex-row space-x-1 rounded-lg bg-blue-100 text-gray-900 p-2 z-10">
           <InfoIcon />
           <span v-text="$i18n.t('setup.preview')" />

--- a/pages/setup.vue
+++ b/pages/setup.vue
@@ -1,103 +1,209 @@
 <template>
-  <div>
-    <section class="pt-12 pb-24 text-center bg-gray-900 text-white">
+  <div class="dark:text-gray-100 dark:bg-gray-900 pb-8">
+    <div class="pt-8 pb-20 text-center bg-red-100 dark:bg-opacity-25 text-black dark:text-gray-100">
+      <img src="/favicon.png" width="64" height="64" class="inline-block bg-red-200 rounded-lg p-2 mb-4">
       <h1 class="text-5xl font-bold uppercase" v-text="$i18n.t('setup.title')" />
-    </section>
-    <section class="container mx-auto setup-panel">
-      <div class="step active">
-        <h1 v-text="$i18n.t('setup.steps.preset')" />
-        <div class="content">
-          <!-- <div>Preset options</div> -->
+    </div>
+    <div class="flex 2xl:flex-row flex-col 2xl:space-x-4 mx-auto px-12 -mt-8">
+      <!-- Column 1: setup panel -->
+      <div class="setup-panel bg-gray-100 dark:bg-gray-800 dark:text-gray-100 border border-gray-300 dark:border-gray-600 shadow-xl rounded-lg divide-y divide-gray-300 dark:divide-gray-700 order-last 2xl:max-w-4xl mt-4 2xl:mt-0 2xl:order-first">
+        <SetupStep :title="$i18n.t('setup.steps.language.title')">
+          <option-group
+            :selected="settingsToApply.lang"
+            :values="{'hu': 'hu', 'en': 'en'}"
+            :translation-key="'settings.values.lang'"
+            @input="settingsToApply.lang = $event"
+          />
+        </SetupStep>
 
-          <div class="grid grid-flow-col grid-cols-3 gap-4">
-            <div
-              v-for="(preset, key) in presets"
-              :key="'preset-' + key"
-              :class="['preset-card', { 'selected': settingsToApply.preset === key }]"
-              role="option"
-              @click="settingsToApply.preset = key"
-            >
-              <h1>
-                <span class="title" v-text="$i18n.t('setup.presets.' + key + '.title')" />
-                <span class="preview">{{ preset.preview }}</span>
-              </h1>
-              <div class="description" v-text="$i18n.t('setup.presets.' + key + '.description')" />
+        <SetupStep :title="$i18n.t('setup.steps.preset.title')" :description="$i18n.t('setup.steps.preset.description')" :attention="mainpreset === undefined">
+          <OptionGroup
+            :values="{ 'minimalist': 'minimalist', 'default': 'default', 'hardcore': 'hardcore' }"
+            :selected="mainpreset"
+            translation-key="setup.presets"
+            @input="mainpreset = $event"
+          />
+        </SetupStep>
+
+        <SetupStep :title="$i18n.t('setup.steps.timerpreset.title')" :description="$i18n.t('setup.steps.timerpreset.description')" :attention="timerpreset === undefined">
+          <option-group
+            :selected="timerpreset"
+            :values="{'easy': 'easy', 'default': 'default', 'advanced': 'advanced', 'workaholic': 'workaholic'}"
+            translation-key="setup.timerpreset"
+            :override-text="timerPresetCustomTexts"
+            @input="timerpreset = $event"
+          />
+        </SetupStep>
+
+        <SetupStep :title="$i18n.t('setup.steps.timerstyle.title')" :description="$i18n.t('setup.steps.timerstyle.description')">
+          <option-group
+            :selected="settingsToApply.currentTimer"
+            :values="{'traditional': 'traditional', 'approximate': 'approxmate', 'percentage': 'percentage'}"
+            translation-key="settings.values.currentTimer"
+            @input="settingsToApply.currentTimer = $event"
+          />
+        </SetupStep>
+
+        <SetupStep
+          :title="$i18n.t('setup.steps.permissions.title')"
+          :description="$i18n.t('setup.steps.permissions.description')"
+        >
+          <div class="flex flex-col space-y-1">
+            <div class="">
+              <input v-model="settingsToApply.permissions.audio" type="checkbox" class="w-5 h-5 rounded">
+              Hang
+            </div>
+            <div class="">
+              <input :checked="settingsToApply.permissions.notifications && browserNotificationPermission === 'granted'" :disabled="browserNotificationPermission && browserNotificationPermission !== 'granted'" type="checkbox" class="w-5 h-5 rounded" @change="setNotificationPermissions">
+              Értesítések
             </div>
           </div>
-        </div>
+        </SetupStep>
+
+        <SetupStep :title="$i18n.t('setup.steps.theme.title')" :description="$i18n.t('setup.steps.theme.description')">
+          <option-group
+            :selected="settingsToApply.visuals.darkMode === true ? 'dark' : (settingsToApply.visuals.darkMode === false ? 'light' : null)"
+            :values="{ 'light': false, 'dark': true }"
+            translation-key="setup.theme"
+            @input="settingsToApply.visuals.darkMode = ($event === 'dark')"
+          />
+        </SetupStep>
+
+        <a href="/timer" :class="['bg-green-600 text-white font-bold text-lg text-center p-2 rounded-lg border border-green-700 uppercase hover:bg-green-700 cursor-pointer m-4 mt-0 flex flex-row items-center justify-center space-x-1', { 'opacity-60 pointer-events-none': completedSteps < 4 }]" role="button">
+          <ReadyIcon />
+          <span v-text="$i18n.t('setup.startButton')" />
+        </a>
       </div>
 
-      <!-- <div class="step">
-        <h1>Engedélyek</h1>
-        <div class="description">
-          Engedélyezd, hogy hangot játsszon le az alkalmazás és/vagy hogy értesítést küldjön, ha lejárt az idő. Megígérjük, nem fogunk visszaélni ezekkel!
+      <!-- Column 2: timer preview -->
+      <div class="sticky top-1 rounded-lg w-full h-[420px] overflow-hidden shadow-lg pointer-events-none">
+        <TimerPage preview />
+        <div class="absolute top-2 left-2 flex flex-row space-x-1 rounded-lg bg-blue-100 text-gray-900 p-2 z-10">
+          <InfoIcon />
+          <span v-text="$i18n.t('setup.preview')" />
         </div>
-      </div> -->
-
-      <div class="finish-button" role="button" @click="applyFinalSettings" v-text="$i18n.t('setup.startButton')" />
-    </section>
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
+import { CheckIcon, InfoCircleIcon } from 'vue-tabler-icons'
+import { getNotificationPermissions } from '@/assets/utils/notifications'
 import { AvailableTimers } from '@/store/settings'
+import OptionGroup from '~/components/base/optionGroup.vue'
+import TimerPage from '@/pages/timer.vue'
+import { mergeDeep } from '@/assets/utils/mergeDeep'
+import SetupStep from '@/components/setup/step.vue'
 
 export default {
   name: 'PageSetup',
+  components: {
+    ReadyIcon: CheckIcon,
+    OptionGroup,
+    TimerPage,
+    InfoIcon: InfoCircleIcon,
+    SetupStep
+  },
+
   data () {
     return {
       step: 0,
+      browserNotificationPermission: null,
+      mainpreset: undefined,
+      timerpreset: undefined,
+      originalAppState: JSON.parse(JSON.stringify(this.$store.state.settings)),
       settingsToApply: {
-        preset: 'default'
+        lang: this.$i18n.locale,
+        permissions: {
+          audio: this.$store.state.settings.permissions.audio,
+          notifications: this.$store.state.settings.permissions.notifications
+        },
+        visuals: {
+          darkMode: this.$store.state.settings.visuals.darkMode
+        },
+        currentTimer: this.$store.state.settings.currentTimer
       },
       presets: {
-        traditional: {
-          preview: '25-5-15',
+        minimalist: {
           settings: {
+            // disable schedule
             schedule: {
-              lengths: {
-                work: 25 * 60 * 1000, // 25 minutes
-                shortpause: 5 * 60 * 1000, // 5 minutes
-                longpause: 15 * 60 * 1000 // 15 minutes
+              visibility: {
+                enabled: false,
+                showSectionType: false
               }
             },
-            adaptiveTicking: {
+            // disable tasks
+            tasks: {
               enabled: false
-            },
-            currentTimer: AvailableTimers.TIMER_TRADITIONAL
+            }
           }
         },
         default: {
-          preview: '25-5-15',
           settings: {
+            // enable schedule
             schedule: {
-              lengths: {
-                work: 25 * 60 * 1000, // 25 minutes
-                shortpause: 5 * 60 * 1000, // 5 minutes
-                longpause: 15 * 60 * 1000 // 15 minutes
+              visibility: {
+                enabled: true,
+                showSectionType: true
               }
             },
-            adaptiveTicking: {
-              enabled: true
+            // disable tasks
+            tasks: {
+              enabled: false
             },
             currentTimer: AvailableTimers.TIMER_APPROXIMATE
           }
         },
         hardcore: {
-          preview: '50-10-30',
           settings: {
+            // enable schedule
             schedule: {
-              lengths: {
-                work: 50 * 60 * 1000, // 50 minutes
-                shortpause: 10 * 60 * 1000, // 10 minutes
-                longpause: 30 * 60 * 1000 // 30 minutes
+              visibility: {
+                enabled: true,
+                showSectionType: true
               }
             },
-            adaptiveTicking: {
+            // disable tasks
+            tasks: {
               enabled: true
-            },
-            currentTimer: AvailableTimers.TIMER_PERCENTAGE
+            }
           }
+        }
+      },
+      presetTimers: {
+        default: {
+          lengths: {
+            work: 25 * 60 * 1000, // 25 minutes
+            shortpause: 5 * 60 * 1000, // 5 minutes
+            longpause: 15 * 60 * 1000 // 15 minutes
+          },
+          longPauseInterval: 3 // every 3rd pause is a long one
+        },
+        easy: {
+          lengths: {
+            work: 15 * 60 * 1000, // 15 minutes
+            shortpause: 5 * 60 * 1000, // 5 minutes
+            longpause: 15 * 60 * 1000 // 15 minutes
+          },
+          longPauseInterval: 2 // every 2nd pause is a long one
+        },
+        advanced: {
+          lengths: {
+            work: 40 * 60 * 1000, // 40 minutes
+            shortpause: 10 * 60 * 1000, // 10 minutes
+            longpause: 30 * 60 * 1000 // 30 minutes
+          },
+          longPauseInterval: 3 // every 3rd pause is a long one
+        },
+        workaholic: {
+          lengths: {
+            work: 50 * 60 * 1000, // 50 minutes
+            shortpause: 10 * 60 * 1000, // 5 minutes
+            longpause: 30 * 60 * 1000 // 20 minutes
+          },
+          longPauseInterval: 3 // every 3rd pause is a long one
         }
       }
     }
@@ -108,81 +214,105 @@ export default {
       title: `AnotherPomodoro: ${this.$i18n.t('setup.head').toLowerCase()}`,
       meta: [{
         hid: 'description',
-        content: 'Set up AnotherPomdoro for use using this setup page.'
+        content: 'Set up AnotherPomdoro for first use using this setup page.'
       }]
     }
+  },
+
+  computed: {
+    completedSteps () {
+      let completed = 0
+
+      completed += this.mainpreset !== undefined ? 1 : 0
+      completed += this.timerpreset !== undefined ? 1 : 0
+      completed += this.settingsToApply.lang !== undefined ? 1 : 0
+      completed += this.settingsToApply.visuals.darkMode !== undefined ? 1 : 0
+
+      return completed
+    },
+
+    newSettings () {
+      return mergeDeep(this.presets[this.mainpreset] ? this.presets[this.mainpreset].settings : {}, this.settingsToApply)
+    },
+
+    timerPresetCustomTexts () {
+      const customText = {
+        title: {},
+        description: {}
+      }
+
+      for (const key in this.presetTimers) {
+        if (Object.hasOwnProperty.call(this.presetTimers, key)) {
+          const preset = this.presetTimers[key]
+          customText.description[key] = this.$i18n.t('setup.timerpreset.description', {
+            brief: this.$i18n.t('setup.timerpreset._valueDescription.' + key),
+            worklength: preset.lengths.work / 60000,
+            splength: preset.lengths.shortpause / 60000,
+            lplength: preset.lengths.longpause / 60000,
+            lpfreq: preset.longPauseInterval
+          })
+        }
+      }
+
+      return customText
+    }
+  },
+
+  watch: {
+    newSettings: {
+      handler () {
+        this.$store.replaceState(
+          Object.assign(
+            {},
+            this.$store.state,
+            {
+              settings: mergeDeep(this.$store.state.settings, this.newSettings)
+            }
+          )
+        )
+        this.$store.commit('settings/_updated')
+      },
+      deep: true
+    },
+
+    mainpreset (newValue) {
+      this.settingsToApply = mergeDeep(this.settingsToApply, newValue ? this.presets[newValue].settings : {})
+    },
+
+    timerpreset (newValue) {
+      this.settingsToApply = mergeDeep(this.settingsToApply, newValue ? { schedule: this.presetTimers[newValue] } : {})
+    }
+  },
+
+  mounted () {
+    let finalPermission = null
+    if (typeof Notification === 'undefined' || (typeof Notifaction !== 'undefined' && Notification.permission === 'denied')) {
+      finalPermission = 'denied'
+    }
+
+    this.browserNotificationPermission = finalPermission
   },
 
   methods: {
     applyFinalSettings () {
       const finalOptions = {
-        ...this.presets[this.settingsToApply.preset].settings
+        ...this.presets[this.mainpreset].settings
       }
 
       this.$store.commit('settings/mergeSettings', finalOptions)
 
       this.$router.push('/timer')
+    },
+
+    async setNotificationPermissions () {
+      if (this.browserNotificationPermission === null) {
+        const permission = await getNotificationPermissions()
+        if (permission !== 'granted') {
+          this.settingsToApply.permissions.notifications = false
+        }
+        this.browserNotificationPermission = permission
+      }
     }
   }
 }
 </script>
-
-<style lang="scss" scoped>
-section.setup-panel {
-  @apply bg-gray-100 border border-gray-300 shadow-xl rounded-lg -mt-8 divide-y divide-gray-400;
-
-  & > .step {
-    @apply p-4;
-
-    & > h1 {
-      @apply text-2xl font-bold uppercase text-gray-800 mb-2;
-    }
-
-    & > .content {
-      @apply overflow-hidden scale-y-0 transform;
-
-      transition: transform 500ms ease-out;
-    }
-
-    &.active > .content {
-      @apply scale-y-100;
-    }
-
-    & > .description {
-      @apply text-black text-opacity-90 -mt-1;
-    }
-  }
-
-  div.preset-card {
-    @apply bg-gray-50 p-3 border border-gray-200 text-black cursor-pointer select-none;
-
-    h1 {
-      @apply text-lg;
-
-      & > span.title {
-        @apply font-bold uppercase;
-      }
-
-      & > span.preview {
-        @apply float-right;
-      }
-    }
-
-    & > div.description {
-      @apply text-opacity-80 text-black;
-    }
-
-    &.selected {
-      @apply bg-primary text-white shadow-md;
-
-      & > div.description {
-        @apply text-white;
-      }
-    }
-  }
-
-  .finish-button {
-    @apply bg-green-600 text-white font-bold text-lg text-center p-2 rounded-lg border border-green-700 uppercase hover:bg-green-700 cursor-pointer m-4 mt-0;
-  }
-}
-</style>

--- a/pages/timer.vue
+++ b/pages/timer.vue
@@ -1,12 +1,12 @@
 <template>
-  <section class="timer-section">
+  <section :class="['timer-section', {'dark' : $store.state.settings.visuals.darkMode }]">
     <!-- Dark mode background override -->
     <div class="absolute w-full h-full dark:bg-gray-900" />
 
     <!-- Settings button -->
     <ui-button subtle :class="['absolute', { 'pointer-events-none': preview }]" style="top: 0.5rem; right: 0.5rem; z-index: 10;" @click="showSettings = true">
       <client-only>
-        <cog-icon class="text-lg" :title="$i18n.t('settings.heading')" />
+        <cog-icon class="dark:text-gray-200" :title="$i18n.t('settings.heading')" />
       </client-only>
     </ui-button>
     <!-- Settings panel -->
@@ -54,7 +54,7 @@
             :timer-widget="$store.state.settings.currentTimer"
             class="grid absolute place-items-center"
           />
-          <timer-controls :class="['absolute', { 'pointer-events-none': preview }]" style="bottom: 2rem;" :can-use-keyboard="!showSettings" />
+          <timer-controls :class="['absolute', { 'pointer-events-none': preview }]" style="bottom: 2rem;" :can-use-keyboard="!preview && !showSettings" />
           <todo-list v-show="$store.state.settings.tasks.enabled" class="absolute z-10" style="right: 24px; bottom: 24px;" :editing="[0].includes($store.state.schedule.timerState)" />
         </div>
       </ticker>
@@ -98,6 +98,7 @@ export default {
   },
 
   head () {
+    if (this.preview) { return }
     return {
       title: `(${this.remainingTimeString}) ${this.pageTitle}`,
       meta: [{

--- a/store/settings.js
+++ b/store/settings.js
@@ -19,6 +19,7 @@ export const timerPresets = {
 }
 
 export const state = () => ({
+  _updated: false,
   lang: undefined,
   visuals: {
     work: {
@@ -178,6 +179,12 @@ export const mutations = {
     } else {
       currentElement[key[key.length - 1]] = value
     }
+  },
+
+  /// Mutation to force hydration after use of `replaceState`
+  _updated (state) {
+    state._updated = true
+    state._updated = false
   }
 }
 


### PR DESCRIPTION
The setup page is now ready. It allows users to set up the application for first use through a few clicks.

## Features

* The page allows setting the language, a grand preset (enables/disables the schedule and the tasks module), timer presets, timer style, permissions and theme.
* It provides a live preview of all the changes
* Points to the settings icon where users can further customise the app

Closes #120