### PR TITLE
feat: Add page transitions

### DIFF
--- a/assets/transitions.scss
+++ b/assets/transitions.scss
@@ -1,2 +1,23 @@
 @import './transitions/fade.scss';
 @import './transitions/slidein.scss';
+
+.layout-enter-active,
+.layout-leave-active {
+  @apply transition-all duration-1000;
+
+  opacity: 0;
+}
+
+.layout-enter,
+.layout-leave-to {
+  @apply opacity-0;
+
+  clip-path: circle(0%);
+}
+
+.layout-enter-to,
+.layout-leave {
+  @apply opacity-100;
+
+  clip-path: circle(100%);
+}

--- a/components/timer/loading.vue
+++ b/components/timer/loading.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="absolute w-full h-full overflow-hidden flex flex-col items-center justify-center bg-gray-800">
+    <div class="flex flex-row space-x-4">
+      <div class="rounded-full w-8 h-8 bg-work flashing anim-timing" />
+      <div class="rounded-full w-8 h-8 bg-shortpause flashing anim-delay-1 anim-timing" />
+      <div class="rounded-full w-8 h-8 bg-longpause flashing anim-delay-2 anim-timing" />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style lang="scss" scoped>
+.flashing {
+  animation-name: flash;
+  animation-duration: 1s;
+  animation-timing-function: cubic-bezier(0.76, 0, 0.24, 1);
+  animation-iteration-count: infinite;
+}
+
+.anim-timing {
+  animation-timing-function: cubic-bezier(0.76, 0, 0.24, 1);
+}
+
+.anim-delay-1 {
+  animation-delay: 300ms;
+}
+
+.anim-delay-2 {
+  animation-delay: 600ms;
+}
+
+@keyframes flash {
+  0% {
+    opacity: 1
+  }
+
+  10% {
+    opacity: 0.6
+  }
+
+  20% {
+    opacity: 0.6;
+  }
+
+  30% {
+    opacity: 1
+  }
+}
+</style>

--- a/layouts/timer.vue
+++ b/layouts/timer.vue
@@ -1,21 +1,26 @@
 <template>
-  <div :class="['w-screen, h-screen relative', { 'dark': darkMode }]">
-    <nuxt />
-    <!-- <portal to="footer">
-      <span>&copy; {{ new Date().getFullYear() }}</span>
-    </portal> -->
-  </div>
+  <transition name="loading" mode="in-out">
+    <LoadingIndicator v-if="loading" />
+    <div v-if="!loading" :class="['w-screen, h-screen relative', { 'dark': darkMode }]">
+      <nuxt />
+    </div>
+  </transition>
 </template>
 
 <script>
+import LoadingIndicator from '@/components/timer/loading.vue'
+
 export default {
   name: 'LayoutTimer',
   components: {
+    LoadingIndicator
   },
   data () {
     return {
+      loading: true
     }
   },
+
   computed: {
     darkMode () {
       return this.$store.state.settings.visuals.darkMode
@@ -30,10 +35,14 @@ export default {
       this.$forceUpdate()
     }
   },
+
   mounted () {
     if (this.updateFinished) {
       this.$forceUpdate()
     }
+
+    // hide the spinner
+    this.loading = false
   }
 }
 </script>
@@ -46,5 +55,19 @@ export default {
 
 footer.timer-footer {
   background-color: transparent;
+}
+
+.loading-enter-active {
+  @apply transition-all duration-1000;
+}
+
+.loading-enter {
+  @apply opacity-60;
+
+  clip-path: circle(0%);
+}
+
+.loading-enter-to {
+  clip-path: circle(100%);
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -20,40 +20,41 @@
     </transition>
 
     <!-- Section 1: intro -->
+
     <Section class="snap-center bg-gray-100 justify-center flex flex-col overflow-hidden items-center">
       <Columns class="flex-col xl:flex-row xl:space-x-16 px-4 xl:px-24 pt-8 xl:pt-0">
         <template #left>
           <!-- App title and CTAs -->
-          <div class="flex flex-col justify-center">
-            <div class="flex flex-row items-start mr-16">
-              <!-- App icon -->
-              <div class="mr-4 mt-1 min-w-max min-h-max">
-                <nuxt-img src="/favicon.png" width="68" height="68" class="bg-red-200 rounded-lg p-2" />
+          <transition name="main-appear" appear>
+            <div v-show="loading.mainText" class="flex flex-col justify-center">
+              <div class="flex flex-row items-start mr-16">
+                <!-- App icon -->
+                <div class="mr-4 mt-1 min-w-max min-h-max">
+                  <nuxt-img src="/favicon.png" width="68" height="68" class="bg-red-200 rounded-lg p-2" />
+                </div>
+                <!-- App name and slogan -->
+                <div class="flex flex-col">
+                  <h1 class="text-3xl md:text-5xl font-bold">
+                    AnotherPomodoro
+                  </h1>
+                  <div class="text-lg md:text-xl" v-text="$i18n.t('index.app_description')" />
+                </div>
               </div>
-              <!-- App name and slogan -->
-              <div class="flex flex-col">
-                <h1 class="text-3xl md:text-5xl font-bold">
-                  AnotherPomodoro
-                </h1>
-                <div class="text-lg md:text-xl" v-text="$i18n.t('index.app_description')" />
+              <!-- CTAs -->
+              <div class="grid grid-flow-row md:grid-flow-col grid-cols-1 md:grid-cols-2 mt-6 gap-2">
+                <nuxt-link v-slot="{ navigate }" to="/timer" custom>
+                  <div class="flex-grow text-center px-6 py-4 bg-amber-300 hover:bg-amber-400 shadow-amber-300/30 hover:shadow-amber-300/60 active:duration-500 active:shadow-xl active:shadow-amber-300/80 active:bg-amber-500 shadow-lg text-2xl rounded-lg font-bold uppercase cursor-pointer transition-all" role="button" @click="navigate" v-text="$i18n.t('index.cta.quickstart')" />
+                </nuxt-link>
+                <nuxt-link v-slot="{ navigate }" to="/setup" custom>
+                  <div class="flex-grow text-center px-6 py-4 bg-slate-300 hover:bg-gray-300 text-2xl rounded-lg font-bold uppercase cursor-pointer transition-all shadow-slate-300/0 hover:shadow-slate-300/40 hover:shadow-lg active:shadow-slate-300/60 active:bg-slate-400" role="button" @click="navigate" v-text="$i18n.t('index.cta.configure')" />
+                </nuxt-link>
               </div>
             </div>
-            <!-- CTAs -->
-            <div class="grid grid-flow-row md:grid-flow-col grid-cols-1 md:grid-cols-2 mt-6 gap-2">
-              <nuxt-link v-slot="{ navigate }" to="/timer" custom>
-                <div class="flex-grow text-center px-6 py-4 bg-amber-300 hover:bg-amber-400 shadow-amber-300/30 hover:shadow-amber-300/60 active:duration-500 active:shadow-xl active:shadow-amber-300/80 active:bg-amber-500 shadow-lg text-2xl rounded-lg font-bold uppercase cursor-pointer transition-all" role="button" @click="navigate" v-text="$i18n.t('index.cta.quickstart')" />
-              </nuxt-link>
-
-              <nuxt-link v-slot="{ navigate }" to="/setup" custom>
-                <div class="flex-grow text-center px-6 py-4 bg-slate-300 hover:bg-gray-300 text-2xl rounded-lg font-bold uppercase cursor-pointer transition-all shadow-slate-300/0 hover:shadow-slate-300/40 hover:shadow-lg active:shadow-slate-300/60 active:bg-slate-400" role="button" @click="navigate" v-text="$i18n.t('index.cta.configure')" />
-              </nuxt-link>
-            </div>
-          </div>
+          </transition>
         </template>
-
         <!-- App screenshot -->
         <template #right>
-          <div class="overflow-hidden order-first xl:order-last mb-12 xl:mb-0 rounded-lg shadow-red-300/60 shadow-lg hover:-translate-y-1 transition hover:shadow-xl hover:shadow-red-300/70 w-full max-w-2xl xl:max-w-max self-center">
+          <div :class="['transition-all duration-1000 hover:duration-300 overflow-hidden order-first xl:order-last mb-12 xl:mb-0 rounded-lg shadow-red-300/60 shadow-lg hover:-translate-y-1 hover:shadow-xl hover:shadow-red-300/70 w-full max-w-2xl xl:max-w-max self-center', { 'opacity-0 translate-x-4': !loading.screenshot }]">
             <nuxt-img
               class=""
               src="/assets/img/screenshots/720p/Timer_Default_2x.png"
@@ -65,7 +66,6 @@
           </div>
         </template>
       </Columns>
-
       <template #after>
         <div class="flex-grow xl:absolute xl:bottom-4 flex flex-col items-center justify-end">
           <!-- Source code, support and social buttons -->
@@ -87,7 +87,6 @@
               utm-tags="?utm_source=AnotherPomodoro&utm_medium=web&utm_content=home"
             />
           </div>
-
           <!-- Scroll indicator -->
           <ScrollIcon size="42" />
         </div>
@@ -201,6 +200,10 @@ export default {
 
   data () {
     return {
+      loading: {
+        mainText: false,
+        screenshot: false
+      },
       section2: {
         selectedBoxIndex: 0,
         selectedBoxOrder: [1, 2, 1, 2, 1, 3],
@@ -248,6 +251,14 @@ export default {
   },
 
   mounted () {
+    this.$nextTick(() => {
+      this.loading.mainText = true
+
+      setTimeout(() => {
+        this.loading.screenshot = true
+      }, 1000)
+    })
+
     // start animations
     this.selectedBoxInterval = setInterval(() => {
       this.section2.selectedBoxIndex = this.section2.selectedBoxIndex > 4 ? 0 : this.section2.selectedBoxIndex + 1
@@ -289,5 +300,13 @@ export default {
 .fab-transition-enter,
 .fab-transition-leave-to {
   @apply scale-0 opacity-0;
+}
+
+.main-appear-enter-active {
+  @apply transition duration-1000;
+}
+
+.main-appear-enter {
+  @apply opacity-0 -translate-x-4;
 }
 </style>

--- a/pages/setup.vue
+++ b/pages/setup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="dark:text-gray-100 dark:bg-gray-900 pb-8">
+  <div class="dark:text-gray-100 dark:bg-gray-900 pb-8 w-screen h-screen">
     <div class="pt-8 pb-20 text-center bg-red-100 dark:bg-opacity-25 text-black dark:text-gray-100">
       <img src="/favicon.png" width="64" height="64" class="inline-block bg-red-200 rounded-lg p-2 mb-4">
       <h1 class="text-5xl font-bold uppercase" v-text="$i18n.t('setup.title')" />
@@ -106,6 +106,11 @@ export default {
     TimerPage,
     InfoIcon: InfoCircleIcon,
     SetupStep
+  },
+
+  transition: {
+    name: 'transition-setup',
+    mode: 'out-in'
   },
 
   data () {
@@ -318,3 +323,26 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+.transition-setup-enter-active,
+.transition-setup-leave-active {
+  @apply transition-all duration-500;
+}
+
+.transition-setup-enter {
+  @apply opacity-0 translate-y-4;
+
+  clip-path: circle(0%);
+}
+
+.transition-setup-leave-to {
+  @apply opacity-0 -translate-y-4;
+}
+
+.transition-setup-enter-to {
+  @apply opacity-100 translate-y-0;
+
+  clip-path: circle(75%);
+}
+</style>


### PR DESCRIPTION
Pages now display a transition when navigating and some also when loading.

* The index page plays animations when first loaded
* The timer page has an animated splash screen, so it (hopefully) doesn't jump after it is loaded
* Pages transition during navigation