### PR TITLE
feat: Friendlier error pages

### DIFF
--- a/components/error/action.vue
+++ b/components/error/action.vue
@@ -14,7 +14,7 @@
     ]"
     @click="handleClick"
   >
-    <div :class="['relative flex px-3 py-2 flex-row space-x-1', { 'text-white': textColours && state === 'recommended', 'text-black': textColours && state !== 'recommended' }]">
+    <div :class="['relative flex px-3 py-2 flex-row space-x-1 pointer-events-none', { 'text-white': textColours && state === 'recommended', 'text-black': textColours && state !== 'recommended' }]">
       <slot name="icon" />
       <slot />
     </div>

--- a/components/error/action.vue
+++ b/components/error/action.vue
@@ -1,0 +1,56 @@
+<template>
+  <a
+    role="button"
+    :href="state !== 'disabled' ? href : null"
+    :aria-disabled="state === 'disabled'"
+    :disabled="state === 'disabled'"
+    :class="[
+      'transition relative overflow-hidden rounded-lg bg-current outline-current before:block before:absolute before:inset-0 before:transition',
+      {
+        'outline outline-offset-2 before:bg-black before:bg-opacity-0 before:hover:bg-opacity-10 before:active:bg-opacity-20 cursor-pointer': state === 'recommended',
+        'before:bg-slate-100 before:bg-opacity-70 before:hover:bg-opacity-50 before:active:bg-opacity-30 cursor-pointer': state === 'default',
+        'opacity-60 cursor-not-allowed': state === 'disabled'
+      }
+    ]"
+    @click="handleClick"
+  >
+    <div :class="['relative flex px-3 py-2 flex-row space-x-1', { 'text-white': textColours && state === 'recommended', 'text-black': textColours && state !== 'recommended' }]">
+      <slot name="icon" />
+      <slot />
+    </div>
+  </a>
+</template>
+
+<script>
+export default {
+  props: {
+    state: {
+      type: String,
+      default: 'default',
+      validator (value) {
+        return ['recommended', 'default', 'disabled'].includes(value)
+      }
+    },
+
+    textColours: {
+      type: Boolean,
+      default: false
+    },
+
+    href: {
+      type: String,
+      default: null
+    }
+  },
+
+  methods: {
+    handleClick (event) {
+      if (this.state === 'disabled') {
+        return
+      }
+
+      this.$emit('click', event)
+    }
+  }
+}
+</script>

--- a/components/error/actionBar.vue
+++ b/components/error/actionBar.vue
@@ -54,6 +54,7 @@ export default {
       secondary: 2
     }
 
+    // collect all nodes with a `data-row` attribute
     this.items = []
     this.$refs.items.querySelectorAll('[data-row]').forEach((node) => {
       this.items.push(node)

--- a/components/error/actionBar.vue
+++ b/components/error/actionBar.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="flex flex-col space-y-4 items-center">
+    <div v-text="$i18n.t('errorpage.suggestions.primary')" />
+    <div ref="primary" class="flex flex-col lg:flex-row space-y-3 md:space-x-2">
+      <!-- Recommended row  -->
+    </div>
+    <div v-text="$i18n.t('errorpage.suggestions.secondary')" />
+    <div ref="secondary" class="mt-4 flex flex-col lg:flex-row space-y-3 md:space-x-2">
+      <!-- Secondary row -->
+    </div>
+    <div ref="items" class="hidden">
+      <!-- Hide items by default -->
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      items: []
+    }
+  },
+
+  watch: {
+    items (newValue) {
+      try {
+        // Clear child nodes
+        [this.$refs.primary, this.$refs.secondary].forEach((row) => {
+          while (row.hasChildNodes()) {
+            row.removeChild(row.firstChild)
+          }
+        })
+
+        // Add nodes back in
+        newValue.forEach((node) => {
+          if (['recommended', 'primary'].includes(node.dataset.row)) {
+            this.$refs.primary.appendChild(node)
+          } else if (node.dataset.row === 'secondary') {
+            this.$refs.secondary.appendChild(node)
+          }
+        })
+      } catch (e) {
+        // console.error(e)
+      }
+    }
+  },
+
+  mounted () {
+    const sortOrder = {
+      recommended: 0,
+      primary: 1,
+      secondary: 2
+    }
+
+    this.items = []
+    this.$refs.items.querySelectorAll('[data-row]').forEach((node) => {
+      this.items.push(node)
+    })
+
+    // sort items: recommended > primary > secondary
+    this.items.sort((nodeA, nodeB) => Math.sign(sortOrder[nodeA.dataset.row] - sortOrder[nodeB.dataset.row]))
+  }
+}
+</script>

--- a/components/error/actionBar.vue
+++ b/components/error/actionBar.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="flex flex-col space-y-4 items-center">
     <div v-text="$i18n.t('errorpage.suggestions.primary')" />
-    <div ref="primary" class="flex flex-col lg:flex-row space-y-3 md:space-x-2">
+    <div ref="primary" class="flex flex-col lg:flex-row space-y-4 md:space-y-0 md:space-x-2">
       <!-- Recommended row  -->
     </div>
     <div v-text="$i18n.t('errorpage.suggestions.secondary')" />
-    <div ref="secondary" class="mt-4 flex flex-col lg:flex-row space-y-3 md:space-x-2">
+    <div ref="secondary" class="mt-4 flex flex-col lg:flex-row space-y-4 md:space-x-2 md:space-y-0">
       <!-- Secondary row -->
     </div>
     <div ref="items" class="hidden">

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -430,7 +430,7 @@ export default {
     },
     suggestions: {
       primary: 'You can',
-      secondary: 'Or if those didn\'t help'
+      secondary: 'or if those didn\'t help'
     }
   }
 }

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -409,5 +409,28 @@ export default {
     empty: 'No tasks yet',
     manage: 'Manage'
   },
-  ready: 'Done'
+  ready: 'Done',
+  errorpage: {
+    title: {
+      crash: 'The app crashed',
+      notfound: 'That page does not exist',
+      other: 'Something went wrong'
+    },
+    action: {
+      reset: 'Reset the app',
+      reload: 'Reload the page',
+      home: 'Go back to the home page',
+      githubIssue: 'File a bug report',
+      githubDiscussion: 'Ask others if they have the same issue',
+      twitter: 'Write a friendly tweet'
+    },
+    showError: {
+      main: 'Show me the error message!',
+      sub: 'I\'ll use it to report an issue or ask if others experience it, too.'
+    },
+    suggestions: {
+      primary: 'You can',
+      secondary: 'Or if those didn\'t help'
+    }
+  }
 }

--- a/i18n/hu.js
+++ b/i18n/hu.js
@@ -405,5 +405,28 @@ export default {
     empty: 'Nincs felvett teendő',
     manage: 'Kezelés'
   },
-  ready: 'Kész'
+  ready: 'Kész',
+  errorpage: {
+    title: {
+      crash: 'Összeomlott az alkalmazás',
+      notfound: 'Ilyen oldal nincs',
+      other: 'Valami elromlott'
+    },
+    action: {
+      reset: 'Alaphelyzetbe állítás',
+      reload: 'Oldal újratöltése',
+      home: 'Vissza a kezdőlapra',
+      githubIssue: 'Hiba bejelentése',
+      githubDiscussion: 'Mások megkérdezése a hibáról',
+      twitter: 'Egy barátságos tweet írása'
+    },
+    showError: {
+      main: 'Mutasd a hibaüzenetet!',
+      sub: 'Ha hibajelentést írok vagy másokat kérdezek meg, ezt is megmutatom.'
+    },
+    suggestions: {
+      primary: 'Először próbáld meg ezeket:',
+      secondary: 'vagy ha a fentiek nem segítettek:'
+    }
+  }
 }

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,20 +1,114 @@
 <template>
-  <div class="p-4">
-    <h1 v-if="error.statusCode === 404">
-      {{ pageNotFound }}
-    </h1>
-    <h1 v-else>
-      {{ otherError }}
-    </h1>
-    <NuxtLink to="/">
-      Home page
-    </NuxtLink>
+  <div class="w-screen h-screen flex flex-col items-center justify-center bg-gray-900 text-gray-100 p-6">
+    <div>
+      <component :is="errorHeading.icon" size="128" stroke-width="1.25" />
+    </div>
+    <h1 class="mt-2 text-5xl text-center uppercase font-bold tracking-tighter" v-text="errorHeading.title" />
+
+    <div class="mt-8 max-w-screen-lg border-2 border-gray-300 rounded-lg overflow-hidden">
+      <transition name="showerror-transition" mode="out-in">
+        <div v-if="!showError" class="transition p-4 bg-gray-700 hover:bg-gray-600 active:bg-gray-800 text-gray-100 flex flex-row items-center space-x-4 cursor-pointer" role="button" @click="showError = true">
+          <IconShowError size="42" />
+          <div>
+            <div class="font-bold" v-text="$i18n.t('errorpage.showError.main')" />
+            <div v-text="$i18n.t('errorpage.showError.sub')" />
+          </div>
+        </div>
+        <pre v-if="showError" class="p-4 overflow-y-scroll max-h-56" v-text="fullError" />
+      </transition>
+    </div>
+
+    <!-- Recommended actions -->
+    <ActionBar class="mt-8">
+      <ActionButton v-bind="getRowAndState('reset')" class="text-red-500" text-colours @click="actionReset">
+        <IconReset />
+        <p v-text="$i18n.t('errorpage.action.reset')" />
+      </ActionButton>
+      <ActionButton v-bind="getRowAndState('reload')" class="text-blue-500" text-colours @click="actionReload">
+        <IconReload />
+        <p v-text="$i18n.t('errorpage.action.reload')" />
+      </ActionButton>
+      <ActionButton v-bind="getRowAndState('home')" class="text-emerald-500" text-colours href="/">
+        <IconHome />
+        <p v-text="$i18n.t('errorpage.action.home')" />
+      </ActionButton>
+      <ActionButton v-bind="getRowAndState('githubIssue')" class="text-gray-400" text-colours href="https://github.com/Hanziness/AnotherPomodoro/issues?utm_source=AnotherPomodor&utm_medium=web&utm_content=error">
+        <IconGithub />
+        <p v-text="$i18n.t('errorpage.action.githubIssue')" />
+      </ActionButton>
+      <ActionButton v-bind="getRowAndState('githubDiscussion')" class="text-gray-400" text-colours href="https://github.com/Hanziness/AnotherPomodoro/discussions?utm_source=AnotherPomodor&utm_medium=web&utm_content=error">
+        <IconDiscussion />
+        <p v-text="$i18n.t('errorpage.action.githubDiscussion')" />
+      </ActionButton>
+      <ActionButton v-bind="getRowAndState('twitter')" class="text-[#1da1f2]" text-colours href="https://twitter.com/AnotherPomodoro?utm_source=AnotherPomodor&utm_medium=web&utm_content=error">
+        <IconTwitter />
+        <p v-text="$i18n.t('errorpage.action.twitter')" />
+      </ActionButton>
+    </ActionBar>
   </div>
 </template>
 
 <script>
+import { MoodSadIcon, RoadSignIcon, MoodConfuzedIcon, RefreshAlertIcon, RefreshIcon, HomeIcon, BrandGithubIcon, BrandTwitterIcon, MessagesIcon, BugIcon } from 'vue-tabler-icons'
+import ActionButton from '@/components/error/action.vue'
+import ActionBar from '@/components/error/actionBar.vue'
+
+const actionType = {
+  RECOMMEND: 'recommended',
+  PRIMARY: 'primary',
+  SECONDARY: 'secondary',
+  HIDE: 'disabled'
+}
+
+/** Action button presets */
+const actions = {
+  crash: {
+    reload: actionType.RECOMMEND,
+    reset: actionType.PRIMARY,
+    home: actionType.PRIMARY,
+    githubIssue: actionType.SECONDARY,
+    githubDiscussion: actionType.SECONDARY,
+    twitter: actionType.SECONDARY
+  },
+
+  notfound: {
+    home: actionType.RECOMMEND,
+    githubDiscussion: actionType.SECONDARY,
+    twitter: actionType.SECONDARY
+  },
+
+  other: {
+    reload: actionType.RECOMMEND,
+    home: actionType.PRIMARY,
+    reset: actionType.PRIMARY,
+    githubIssue: actionType.SECONDARY,
+    githubDiscussion: actionType.SECONDARY,
+    twitter: actionType.SECONDARY
+  }
+}
+
 export default {
   name: 'LayoutError',
+  components: {
+    // Error reason icons
+    IconCrash: MoodSadIcon,
+    IconLost: RoadSignIcon,
+    IconOtherError: MoodConfuzedIcon,
+
+    // Show error icon
+    IconShowError: BugIcon,
+
+    // Action icons
+    IconReset: RefreshAlertIcon,
+    IconReload: RefreshIcon,
+    IconHome: HomeIcon,
+    IconGithub: BrandGithubIcon,
+    IconDiscussion: MessagesIcon,
+    IconTwitter: BrandTwitterIcon,
+
+    ActionButton,
+    ActionBar
+  },
   layout: 'empty',
   props: {
     error: {
@@ -24,22 +118,108 @@ export default {
   },
   data () {
     return {
-      pageNotFound: '404 Not Found',
-      otherError: 'An error occurred'
+      showError: false
     }
   },
+
   head () {
-    const title =
-      this.error.statusCode === 404 ? this.pageNotFound : this.otherError
     return {
-      title
+      title: this.errorHeading.title
+    }
+  },
+
+  computed: {
+    /** Determines what type of error happened */
+    errorType () {
+      if (this.error.statusCode >= 500) { return 'crash' }
+      if (this.error.statusCode === 404) { return 'notfound' }
+      return 'other'
+    },
+
+    /** The title and icon to show on the error page.
+     * For example on a 404 error it would show "Looks like you're lost",
+     * but on an app error (eg. "crash" because of a store error) it would show
+     * "Oops, the app crashed". Can return the icon as well.
+     */
+    errorHeading () {
+      let icon = 'IconOtherError'
+
+      if (this.errorType === 'crash') {
+        icon = 'IconCrash'
+      } else if (this.errorType === 'notfound') {
+        icon = 'IconLost'
+      }
+
+      return {
+        title: this.$i18n.t('errorpage.title.' + this.errorType),
+        icon
+      }
+    },
+
+    /** Returns actions to show or recommend based on the error.
+     * For example if it's a 404 error, go to home or the
+     * discussion button is recommended but the reset button is hidden.
+     */
+    recommendedActions () {
+      return actions[this.errorType]
+    },
+
+    fullError () {
+      return Object.assign({}, this.error, { route: this.$route })
+    }
+  },
+
+  methods: {
+    getRowAndState (action) {
+      let row = 'hidden'
+      let state = 'disabled'
+
+      if (this.recommendedActions[action] && this.recommendedActions[action] === actionType.RECOMMEND) {
+        state = 'recommended'
+        row = 'recommended'
+      }
+
+      if (this.recommendedActions[action] && [actionType.PRIMARY, actionType.SECONDARY].includes(this.recommendedActions[action])) {
+        state = 'default'
+        row = this.recommendedActions[action]
+      }
+
+      if (['githubIssue', 'githubDiscussion'].includes(action)) {
+        if (!this.showError) {
+          state = 'disabled'
+        }
+      }
+
+      return {
+        'data-row': row,
+        state
+      }
+    },
+
+    /// Ask settings to reset and navigate back to the home page
+    actionReset () {
+      this.$store.commit('settings/setReset', true)
+      location.assign('/')
+    },
+
+    /// Reload the current page
+    actionReload () {
+      location.reload()
     }
   }
 }
 </script>
 
-<style scoped>
-h1 {
-  font-size: 20px;
+<style lang="scss" scoped>
+.showerror-transition-enter-active {
+  @apply transition-all duration-700;
+}
+
+.showerror-transition-enter {
+  clip-path: circle(0%);
+}
+
+.showerror-transition-enter-to {
+  clip-path: circle(75%);
 }
 </style>

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -5,6 +5,7 @@
     </div>
     <h1 class="mt-2 text-5xl text-center uppercase font-bold tracking-tighter" v-text="errorHeading.title" />
 
+    <!-- Error description -->
     <div class="mt-8 max-w-screen-lg border-2 border-gray-300 rounded-lg overflow-hidden">
       <transition name="showerror-transition" mode="out-in">
         <div v-if="!showError" class="transition p-4 bg-gray-700 hover:bg-gray-600 active:bg-gray-800 text-gray-100 flex flex-row items-center space-x-4 cursor-pointer" role="button" @click="showError = true">

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -23,27 +23,27 @@
     <ActionBar class="mt-8">
       <ActionButton v-bind="getRowAndState('reset')" class="text-red-500" text-colours @click="actionReset">
         <IconReset />
-        <p v-text="$i18n.t('errorpage.action.reset')" />
+        <div v-text="$i18n.t('errorpage.action.reset')" />
       </ActionButton>
       <ActionButton v-bind="getRowAndState('reload')" class="text-blue-500" text-colours @click="actionReload">
         <IconReload />
-        <p v-text="$i18n.t('errorpage.action.reload')" />
+        <div v-text="$i18n.t('errorpage.action.reload')" />
       </ActionButton>
       <ActionButton v-bind="getRowAndState('home')" class="text-emerald-500" text-colours href="/">
         <IconHome />
-        <p v-text="$i18n.t('errorpage.action.home')" />
+        <div v-text="$i18n.t('errorpage.action.home')" />
       </ActionButton>
       <ActionButton v-bind="getRowAndState('githubIssue')" class="text-gray-400" text-colours href="https://github.com/Hanziness/AnotherPomodoro/issues?utm_source=AnotherPomodor&utm_medium=web&utm_content=error">
         <IconGithub />
-        <p v-text="$i18n.t('errorpage.action.githubIssue')" />
+        <div v-text="$i18n.t('errorpage.action.githubIssue')" />
       </ActionButton>
       <ActionButton v-bind="getRowAndState('githubDiscussion')" class="text-gray-400" text-colours href="https://github.com/Hanziness/AnotherPomodoro/discussions?utm_source=AnotherPomodor&utm_medium=web&utm_content=error">
         <IconDiscussion />
-        <p v-text="$i18n.t('errorpage.action.githubDiscussion')" />
+        <div v-text="$i18n.t('errorpage.action.githubDiscussion')" />
       </ActionButton>
       <ActionButton v-bind="getRowAndState('twitter')" class="text-[#1da1f2]" text-colours href="https://twitter.com/AnotherPomodoro?utm_source=AnotherPomodor&utm_medium=web&utm_content=error">
         <IconTwitter />
-        <p v-text="$i18n.t('errorpage.action.twitter')" />
+        <div v-text="$i18n.t('errorpage.action.twitter')" />
       </ActionButton>
     </ActionBar>
   </div>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -99,6 +99,11 @@ export default defineNuxtConfig({
   /** Modules that need to be transpiled */
   transpileDependencies: ['vuex-persist'],
 
+  generate: {
+    // Generate fallback pages (makes error pages work on Netlify, too)
+    fallback: true
+  },
+
   /**
    * PWA module settings
    */

--- a/store/settings.js
+++ b/store/settings.js
@@ -181,6 +181,10 @@ export const mutations = {
     }
   },
 
+  setReset (state, shouldReset) {
+    state.reset = shouldReset
+  },
+
   /// Mutation to force hydration after use of `replaceState`
   _updated (state) {
     state._updated = true


### PR DESCRIPTION
This PR adds friendlier and more helpful error handling to the application, notably to 404 and application errors. The error page offers and recommends actions based on the error with the option to display a JSON error message - which, when shown, enables the buttons that lead to the GitHub repository.

![AnotherPomodoro - Error - Not found](https://user-images.githubusercontent.com/18259108/147856445-d788da58-7157-40a6-982e-c385ca8fae70.png)

![AnotherPomodoro - Error - App crash](https://user-images.githubusercontent.com/18259108/147856449-a101c798-7f63-4c6a-9ac1-29619bfbeea8.png)

Closes #126 