### PR TITLE
refactor(theme): Change accent colour so it better matches branding

### DIFF
--- a/components/base/option.vue
+++ b/components/base/option.vue
@@ -2,7 +2,7 @@
   <button
     class="px-3 py-4 border border-solid border-gray-300 rounded-lg bg-white text-left dark:bg-gray-800 dark:border-gray-600 basis-0 transition-colors flex flex-col justify-start"
     :class="[{
-      'bg-primary dark:bg-primary border-transparent dark:border-transparent ring ring-primary ring-offset-2 dark:ring-offset-slate-800 text-white': active,
+      'bg-primary dark:bg-primary border-transparent dark:border-transparent ring ring-primary ring-offset-2 dark:ring-offset-slate-800 text-primary-font dark:text-primary-font': active,
       'hover:bg-gray-200 dark:hover:bg-gray-600': !active
     }]"
     @click="$emit('click')"

--- a/components/settings/panel/tabHeader.vue
+++ b/components/settings/panel/tabHeader.vue
@@ -1,5 +1,5 @@
 <template functional>
-  <div class="flex-1 h-full p-2 cursor-pointer text-center flex flex-row space-x-1 items-center justify-center select-none rounded-lg box-border transition-colors mx-1 first-of-type:ml-0 last-of-type:mr-0" :class="[{ 'bg-gray-200 dark:bg-gray-800': !props.active, 'bg-primary text-white px-3 md:px-2': props.active }]" v-bind="data.attrs" v-on="listeners">
+  <div class="flex-1 h-full p-2 cursor-pointer text-center flex flex-row space-x-1 items-center justify-center select-none rounded-lg box-border transition-colors mx-1 first-of-type:ml-0 last-of-type:mr-0" :class="[{ 'bg-gray-200 dark:bg-gray-800': !props.active, 'bg-primary text-primary-font dark:text-primary-font px-3 md:px-2': props.active }]" v-bind="data.attrs" v-on="listeners">
     <slot name="icon" />
     <span :class="[{ 'hidden md:block': !props.active }]" v-text="props.text" />
   </div>

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -58,7 +58,7 @@
               <SettingsTime :settings-key="['schedule', 'lengths', 'work']" :min-ms="5000" />
               <SettingsTime :settings-key="['schedule', 'lengths', 'shortpause']" :min-ms="5000" />
               <SettingsTime :settings-key="['schedule', 'lengths', 'longpause']" :min-ms="5000" />
-              <div class="rounded-lg ring-inset ring ring-blue-400 bg-blue-100 dark:bg-gray-700 dark:text-gray-100 px-3 py-4 flex flex-row items-center space-x-2">
+              <div class="rounded-lg ring-inset ring ring-primary bg-primary/20 dark:bg-gray-700 dark:text-gray-100 px-3 py-4 flex flex-row items-center space-x-2">
                 <InfoIcon />
                 <span v-text="$i18n.t('settings.scheduleMinTime')" />
               </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+const colors = require('tailwindcss/colors')
+
 module.exports = {
   content: [
     './components/**/*.{vue,js}',
@@ -15,7 +17,8 @@ module.exports = {
         sans: ['Poppins', 'sans-serif']
       },
       colors: {
-        primary: '#3498db',
+        primary: colors.red[400],
+        'primary-font': colors.black,
         work: '#FF6B6B',
         shortpause: '#F4A261',
         longpause: '#2EC4B6'


### PR DESCRIPTION
This PR changes the app's `primary` colour from the previous blue colour to Tailwind's `red[400]`, which closely matches the colour used behind the app's logo, the app's logo colour and the "work" theme colour.

Closes #142 

![Screenshot of the settings panel with the new accent colour](https://user-images.githubusercontent.com/18259108/148582805-6d4414a0-c03c-46b4-a34f-3c1a45fadcdb.png)
