### PR TITLE
feat: Add Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[[redirects]]
+  from = "/bee.js"
+  to = "https://cdn.splitbee.io/sb.js"
+  status = 200
+
+[[redirects]]
+  from = "/_hive/*"
+  to  = "https://hive.splitbee.io/:splat"
+  status = 200

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -160,7 +160,7 @@ export default defineNuxtConfig({
   },
 
   sitemap: {
-    hostname: process.env.hostname ? process.env.hostname : 'https://another-pomodoro.netlify.app'
+    hostname: process.env.URL ? process.env.URL : 'https://another-pomodoro.netlify.app'
   },
 
   /*


### PR DESCRIPTION
This PR changes the environment variable used for static site generation to `URL` (Netlify will use it instead of the previously configured `hostname`) and adds a Netlify config file with Netlify proxy redirects for Splitbee*.

*As stated in the README, productions deployments on Netlify will sometimes use third-party tools to measure site performance. Currently, [Splitbee](https://splitbee.io/) is set up on the site, but is is being used without cookies. 