### PR TITLE
refactor(i18n): Make adding localisations easier

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,18 @@ AnotherPomodoro is an open software and such it welcomes others to contribute co
 * Make sure your code is fixing [an open issue](https://github.com/Hanziness/AnotherPomodoro/issues?q=is%3Aopen+is%3Aissue). **Don't submit code to issues assigned to others.** If an issue is assigned to someone, they are expected to sooner or later submit their own fixes to it.
 * It's best if you are submitting code that fixes an issue **assigned to you**. If you'd like to work on an issue, please indicate it.
 
+## Submitting translations
+
+While we also accept translations submitted to the app, currently they are stored in `js` files inside the project, which means maintenance will likely be an issue in the future. If there is a bigger need to provide more translations, the project will likely be moved to a translation crowdsourcing platform like Crowdin. As of now, if you want to submit translations for your language, you need to do three things:
+
+1. Create an issue, noting that you would do the localisations for a particular language. Once this is confirmed and you are assigned to the issue, continue with the next steps.
+2. Copy `i18n/en.js` (to eg. `i18n/hu.js`, if you would be making the Hungarian translation) and translate the strings to your chosen language.
+3. Add your language to `nuxt.config.js` (in the `i18n.locales` array). Please make sure to *use the app* as some translations might end up out-of-context if translated blindly. The entry for English translations (stored in `i18n/en.js`) look like this:
+
+```json
+{ code: 'en', name: 'English', iso: 'en-US', file: 'en.js' }
+```
+
 ### Technical requirements
 
 * **Submit code against the `develop` branch!** It contains the most up-to-date development version of the app.

--- a/assets/languages.js
+++ b/assets/languages.js
@@ -1,4 +1,0 @@
-export default {
-  en: 'English',
-  hu: 'Magyar'
-}

--- a/assets/languages.js
+++ b/assets/languages.js
@@ -1,0 +1,4 @@
+export default {
+  en: 'English',
+  hu: 'Magyar'
+}

--- a/components/base/option.vue
+++ b/components/base/option.vue
@@ -53,11 +53,11 @@ export default {
 
   computed: {
     title () {
-      return this.customTitle || this.$i18n.t(this.translationKey + '._values.' + this.translationSubkey)
+      return typeof this.customTitle === 'string' ? this.customTitle : this.$i18n.t(this.translationKey + '._values.' + this.translationSubkey)
     },
 
     description () {
-      return this.customDescription || this.$i18n.t(this.translationKey + '._valueDescription.' + this.translationSubkey)
+      return typeof this.customDescription === 'string' ? this.customDescription : this.$i18n.t(this.translationKey + '._valueDescription.' + this.translationSubkey)
     }
   }
 }

--- a/components/base/optionGroup.vue
+++ b/components/base/optionGroup.vue
@@ -7,8 +7,8 @@
       :active="key === selected"
       :translation-key="translationKey"
       :translation-subkey="key"
-      :custom-title="overrideText.title[key] ? overrideText.title[key] : null"
-      :custom-description="overrideText.description[key] ? overrideText.description[key] : null"
+      :custom-title="overrideText.title == null ? '' : (overrideText.title[key] ? overrideText.title[key] : null)"
+      :custom-description="overrideText.description == null ? '' : (overrideText.description[key] ? overrideText.description[key] : null)"
       @click="select(key)"
     />
   </div>

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -12,9 +12,9 @@
           <Transition tag="div" name="tab-transition" mode="out-in" class="overflow-hidden w-full relative">
             <div v-if="activeTab === 1" :key="1" class="settings-tab">
               <OptionGroup
-                :values="languages"
+                :values="$languages"
                 :selected="$store.state.settings.lang"
-                :override-text="{ title: languages, description: null }"
+                :override-text="{ title: $languages, description: null }"
                 @input="$store.commit('settings/SET', { key: ['lang'], value: $event })"
               />
               <Divider />
@@ -162,7 +162,6 @@ import OptionGroup from '@/components/base/optionGroup.vue'
 import TabHeader from '@/components/settings/panel/tabHeader.vue'
 
 import presetTimers from '@/assets/settings/timerPresets'
-import languages from '@/assets/languages'
 
 export default {
   name: 'SettingsPanel',
@@ -200,8 +199,7 @@ export default {
     return {
       activeTab: 1,
       resetConfirm: false,
-      timerPresets: presetTimers,
-      languages
+      timerPresets: presetTimers
     }
   },
 

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -11,10 +11,11 @@
         <div class="w-full">
           <Transition tag="div" name="tab-transition" mode="out-in" class="overflow-hidden w-full relative">
             <div v-if="activeTab === 1" :key="1" class="settings-tab">
-              <SettingsOptions
-                :settings-key="['lang']"
-                :values="{'en': 'en', 'hu': 'hu'}"
-                :custom-value="$store.state.settings.lang ? $store.state.settings.lang : $i18n.locale"
+              <OptionGroup
+                :values="languages"
+                :selected="$store.state.settings.lang"
+                :override-text="{ title: languages, description: null }"
+                @input="$store.commit('settings/SET', { key: ['lang'], value: $event })"
               />
               <Divider />
               <SettingsCheck :settings-key="['adaptiveTicking', 'enabled']" />
@@ -156,8 +157,12 @@
 
 <script>
 import { XIcon, AdjustmentsIcon, AlarmIcon, ArtboardIcon, InfoCircleIcon, BrandGithubIcon, CoffeeIcon, BrandTwitterIcon, BrandFacebookIcon, BrandRedditIcon } from 'vue-tabler-icons'
+
+import OptionGroup from '@/components/base/optionGroup.vue'
 import TabHeader from '@/components/settings/panel/tabHeader.vue'
+
 import presetTimers from '@/assets/settings/timerPresets'
+import languages from '@/assets/languages'
 
 export default {
   name: 'SettingsPanel',
@@ -169,6 +174,7 @@ export default {
     SettingsTime: () => import(/* webpackMode: "eager" */ '@/components/settings/items/settingsTime.vue'),
     SettingsOptions: () => import(/* webpackMode: "eager" */ '@/components/settings/items/settingsOptions.vue'),
     Divider: () => import(/* webpackMode: "eager" */ '@/components/base/divider.vue'),
+    OptionGroup,
     TabHeader,
     CloseIcon: XIcon,
     // ResetIcon: RefreshAlertIcon,
@@ -194,7 +200,8 @@ export default {
     return {
       activeTab: 1,
       resetConfirm: false,
-      timerPresets: presetTimers
+      timerPresets: presetTimers,
+      languages
     }
   },
 

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -58,11 +58,7 @@ export default {
           description: 'Take a nap or go for a walk',
           duration: '15 minutes'
         }
-      ],
-      try_it: {
-        base: 'If you watch too many videos of cats while you should be working instead, then {0}.',
-        try: 'give it a try'
-      }
+      ]
     },
     faq: {
       title: 'FAQ',
@@ -121,10 +117,6 @@ export default {
           base: 'If you feel that this is a project worth supporting, please {0}.',
           action: 'do so'
         }
-      },
-      method: {
-        github: 'View on GitHub',
-        buymeacoffee: 'Buy the author a coffee'
       },
       credits: 'Made with ❤ by Imre Gera'
     }

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -229,15 +229,7 @@ export default {
     values: {
       lang: {
         _title: 'Language',
-        _description: '',
-        _values: {
-          en: 'English',
-          hu: 'Magyar'
-        },
-        _valueDescription: {
-          en: '',
-          hu: ''
-        }
+        _description: ''
       },
       eventLoggingEnabled: {
         _title: 'Enable event logging',

--- a/i18n/hu.js
+++ b/i18n/hu.js
@@ -226,15 +226,7 @@ export default {
     values: {
       lang: {
         _title: 'Nyelv',
-        _description: '',
-        _values: {
-          en: 'English',
-          hu: 'Magyar'
-        },
-        _valueDescription: {
-          en: '',
-          hu: ''
-        }
+        _description: ''
       },
       eventLoggingEnabled: {
         _title: 'Eseménynaplózás engedélyezése',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -61,6 +61,7 @@ export default defineNuxtConfig({
   */
   plugins: [
     '@/plugins/dayjs.js',
+    '@/plugins/i18nlanguages.js',
     { src: '@/plugins/notifications.client.js', ssr: false },
     { src: '@/plugins/vuex-persist.client.js', ssr: false },
     { src: '@/plugins/i18nwatcher.client.js', ssr: false }

--- a/pages/setup.vue
+++ b/pages/setup.vue
@@ -10,8 +10,8 @@
         <SetupStep :title="$i18n.t('setup.steps.language.title')">
           <OptionGroup
             :selected="settingsToApply.lang"
-            :values="languages"
-            :override-text="{ title: languages, description: null }"
+            :values="$languages"
+            :override-text="{ title: $languages, description: null }"
             @input="settingsToApply.lang = $event"
           />
         </SetupStep>
@@ -99,7 +99,6 @@ import { mergeDeep } from '@/assets/utils/mergeDeep'
 import SetupStep from '@/components/setup/step.vue'
 
 import presetTimers from '@/assets/settings/timerPresets'
-import languages from '@/assets/languages'
 
 export default {
   name: 'PageSetup',
@@ -182,8 +181,7 @@ export default {
           }
         }
       },
-      presetTimers,
-      languages
+      presetTimers
     }
   },
 

--- a/pages/setup.vue
+++ b/pages/setup.vue
@@ -10,8 +10,8 @@
         <SetupStep :title="$i18n.t('setup.steps.language.title')">
           <OptionGroup
             :selected="settingsToApply.lang"
-            :values="{'hu': 'hu', 'en': 'en'}"
-            :translation-key="'settings.values.lang'"
+            :values="languages"
+            :override-text="{ title: languages, description: null }"
             @input="settingsToApply.lang = $event"
           />
         </SetupStep>
@@ -97,7 +97,9 @@ import OptionGroup from '~/components/base/optionGroup.vue'
 import TimerPage from '@/pages/timer.vue'
 import { mergeDeep } from '@/assets/utils/mergeDeep'
 import SetupStep from '@/components/setup/step.vue'
+
 import presetTimers from '@/assets/settings/timerPresets'
+import languages from '@/assets/languages'
 
 export default {
   name: 'PageSetup',
@@ -180,7 +182,8 @@ export default {
           }
         }
       },
-      presetTimers
+      presetTimers,
+      languages
     }
   },
 

--- a/plugins/i18nlanguages.js
+++ b/plugins/i18nlanguages.js
@@ -1,0 +1,12 @@
+/// Inject available language from `$i18n` as $languages
+export default function ({ app }, inject) {
+  const availableLocales = {}
+
+  if (app.i18n) {
+    for (const lang of app.i18n.locales) {
+      availableLocales[lang.code] = lang.name
+    }
+  }
+
+  inject('languages', availableLocales)
+}


### PR DESCRIPTION
This PR makes it easier to add localisations to the app by automating the detection of available languages and their display on the settings panel and the setup page.

## Note
This is only an intermediary solution as updating localisations would still involve a lot of work. If there is a need to add more languages to the app, translations will probably be moved to Crowdin where they are a lot easier to manage.

Closes #151 