### PR TITLE
i18n: Add Croatian translations to Day.js

### DIFF
--- a/plugins/dayjs.js
+++ b/plugins/dayjs.js
@@ -7,6 +7,7 @@ import { AvailableTimers } from '@/store/settings'
 // English and Hungarian locales
 import(/* webpackChunkName: "dayjsLocales", webpackMode: "eager" */ 'dayjs/locale/en.js')
 import(/* webpackChunkName: "dayjsLocales", webpackMode: "eager" */ 'dayjs/locale/hu.js')
+import(/* webpackChunkName: "dayjsLocales", webpackMode: "eager" */ 'dayjs/locale/hr.js')
 
 dayjs.extend(utc)
 dayjs.extend(dayjsrelativetime)


### PR DESCRIPTION
This PR imports the missing Croatian translations into Day.js, making the approximate timer translated, too. Since Day.js is only used to format the timer (which does not involve a lot of extra logic), the related functions could be implemented in AnotherPomodoro as well, to reduce dependencies and let the translations be handled by the app.

Closes #156 