### PR TITLE
fix(settings): OptionGroup items won't overflow

### DIFF
--- a/components/base/optionGroup.vue
+++ b/components/base/optionGroup.vue
@@ -3,7 +3,7 @@
     <OptionControl
       v-for="(item, key) in values"
       :key="key"
-      class="min-w-fit"
+      class="min-w-0"
       :active="key === selected"
       :translation-key="translationKey"
       :translation-subkey="key"


### PR DESCRIPTION
This PR adds a small fix that ensures that grid items in `OptionGroup` won't overflow their grid cells (one such overflow was caused by the Hungarian translation of the default timer preset).