### PR TITLE
chore: Finalize release configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Free and open-source Pomodoro application, right in your browser.
 
-[<img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" width="210">](https://www.buymeacoffee.com/imreg?utm_source=github&utm_medium=web&utm_content=readme)
+[<img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" height="54">](https://www.buymeacoffee.com/imreg?utm_source=github&utm_medium=web&utm_content=readme) <a href="https://www.producthunt.com/posts/anotherpomodoro?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-anotherpomodoro" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=327185&theme=light" alt="AnotherPomodoro - Modern & customizable productivity timer | Product Hunt" width="250" height="54" /></a>
 
 ![Netlify Status](https://api.netlify.com/api/v1/badges/7cb2b7fb-cacd-4acf-803b-8af9dad9f2a8/deploy-status)
 

--- a/README.md
+++ b/README.md
@@ -116,4 +116,6 @@ $ yarn generate
 
 If you like this project or it has helped you, please consider buying the maintainer a coffee. You won't be annoyed to do so while using the app!
 
-[<p align="center"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" width="256"></p>](https://www.buymeacoffee.com/imreg?utm_source=github&utm_medium=web&utm_content=readme)
+<p align="center"><a href="https://www.producthunt.com/posts/anotherpomodoro?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-anotherpomodoro" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=327185&theme=light" alt="AnotherPomodoro - Modern & customizable productivity timer | Product Hunt" width="250" height="54" /></a></p>
+
+[<p align="center"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" width="250"></p>](https://www.buymeacoffee.com/imreg?utm_source=github&utm_medium=web&utm_content=readme)

--- a/netlify.toml
+++ b/netlify.toml
@@ -31,3 +31,8 @@
   from = "/plausible.js"
   to = "https://plausible.io/js/plausible.outbound-links.js"
   status = 200
+
+[[redirects]]
+  from = "/plausible-api"
+  to = "https://plausible.io/api/event"
+  status = 202

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,17 @@
+# Domain redirects
+[[redirects]]
+  from = "http://another-pomodoro.netlify.app/*"
+  to = "https://another-pomodoro.app/*"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "https://another-pomodoro.netlify.app/*"
+  to = "https://another-pomodoro.app/*"
+  status = 301
+  force = true
+
+# Proxying for third-party scripts
 [[redirects]]
   from = "/bee.js"
   to = "https://cdn.splitbee.io/sb.js"

--- a/netlify.toml
+++ b/netlify.toml
@@ -26,3 +26,8 @@
   from = "/fa.js"
   to = "https://fairdatacenter.de/cdn/fair.js"
   status = 200
+
+[[redirects]]
+  from = "/plausible.js"
+  to = "https://plausible.io/js/plausible.js"
+  status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -19,7 +19,7 @@
 
 [[redirects]]
   from = "/_hive/*"
-  to  = "https://hive.splitbee.io/:splat"
+  to = "https://hive.splitbee.io/:splat"
   status = 200
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,3 +21,8 @@
   from = "/_hive/*"
   to  = "https://hive.splitbee.io/:splat"
   status = 200
+
+[[redirects]]
+  from = "/fa.js"
+  to = "https://fairdatacenter.de/cdn/fair.js"
+  status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,13 @@
 # Domain redirects
 [[redirects]]
   from = "http://another-pomodoro.netlify.app/*"
-  to = "https://another-pomodoro.app/*"
+  to = "https://another-pomodoro.app/:splat"
   status = 301
   force = true
 
 [[redirects]]
   from = "https://another-pomodoro.netlify.app/*"
-  to = "https://another-pomodoro.app/*"
+  to = "https://another-pomodoro.app/:splat"
   status = 301
   force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -29,5 +29,5 @@
 
 [[redirects]]
   from = "/plausible.js"
-  to = "https://plausible.io/js/plausible.js"
+  to = "https://plausible.io/js/plausible.outbound-links.js"
   status = 200


### PR DESCRIPTION
This PR adds the remaining missing things to the app:

* the app's domain is now [https://another-pomodoro.app](https://another-pomodoro.app/?utm_source=github&utm_medium=pullrequest&utm_campaign=launch&utm_content=pr_changelog), the previous another-pomodoro.netlify.app should redirect here
* I need to measure site performance, so some privacy-friendly (and no-cookie!) tracking (currently thinking on: Plausible, SplitBee) will be enabled on the production site - note that this PR only modifies the Netlify config, so self-deployed instances still do not have any form of tracking. The changes in the config help me enable these privacy-friendly analytics tools.
* the app is launching on Product Hunt, too, so a badge has been added to the README