### PR TITLE
fix(dev): Exclude node_modules, git folders and nuxt cache from watch

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -200,24 +200,14 @@ export default defineNuxtConfig({
         autoprefixer: {}
       }
     }
-    // babel: {
-    //   presets ({ isServer }) {
-    //     const envTargets = {
-    //       client: { browsers: ['last 2 versions'] },
-    //       server: { node: 'current' }
-    //     }
-    //     const env = isServer ? 'server' : 'client'
-
-    //     return [
-    //       [
-    //         '@nuxt/babel-preset-app',
-    //         {
-    //           targets: envTargets[env],
-    //           corejs: { version: 3 }
-    //         }
-    //       ]
-    //     ]
-    //   }
-    // }
+  },
+  watchers: {
+    chokidar: {
+      ignoreInitial: true,
+      ignored: ['**/node_modules', '**/.git', '**/.nuxt']
+    },
+    webpack: {
+      ignored: ['**/node_modules', '**/.git', '**/.nuxt']
+    }
   }
 })


### PR DESCRIPTION
This PR adds the `ignored` parameters to both the webpack and chokidar watchers, so the number of watched files is much lower (due to `node_modules` being ignored) and the project is not rebuilt multiple times due to changes in `.nuxt/dist`.

Closes #180 