### PR TITLE
feat(tasks): Add placeholder text to new task field

### DIFF
--- a/components/todoList/addTask.vue
+++ b/components/todoList/addTask.vue
@@ -1,6 +1,13 @@
 <template>
-  <div class="flex flex-row space-x-2 rounded-xl bg-gray-100 dark:bg-gray-700 py-4 pl-4 pr-2 focus-within:bg-white dark:focus-within:bg-gray-600 focus-within:shadow-lg shadow-sm transition-all duration-500 focus-within:duration-200 items-center" :style="{ '--theme': $store.getters['schedule/currentScheduleColour'] }">
-    <input v-model="taskTitle" type="text" required class="block min-w-0 bg-transparent dark:bg-transparent border-none rounded-full focus:ring-transparent focus:ring-offset-0 dark:focus:bg-transparent peer flex-grow p-0" @keyup="checkEnter">
+  <div class="rounded-xl dark:bg-gray-700 focus-within:bg-white dark:focus-within:bg-gray-600 focus-within:shadow-lg focus-within:duration-200 flex flex-row items-center py-4 pl-4 pr-2 space-x-2 transition-all duration-500 bg-gray-100 shadow-sm" :style="{ '--theme': $store.getters['schedule/currentScheduleColour'] }">
+    <input
+      v-model="taskTitle"
+      type="text"
+      required
+      class="dark:bg-transparent focus:ring-transparent focus:ring-offset-0 dark:focus:bg-transparent peer flex-grow block min-w-0 p-0 bg-transparent border-none rounded-full"
+      :placeholder="$i18n.t('tasks.addPlaceholder')"
+      @keyup="checkEnter"
+    >
     <button :class="['rounded-lg bg-theme bg-opacity-80 hover:bg-opacity-100 text-white px-3 py-2 -my-3 transition-all', { 'bg-gray-200 opacity-60 dark:opacity-30 pointer-events-none': !valid }]" @click="addTask">
       <CornerDownLeftIcon size="24" />
     </button>

--- a/components/todoList/addTask.vue
+++ b/components/todoList/addTask.vue
@@ -4,7 +4,7 @@
       v-model="taskTitle"
       type="text"
       required
-      class="dark:bg-transparent focus:ring-transparent focus:ring-offset-0 dark:focus:bg-transparent peer flex-grow block min-w-0 p-0 bg-transparent border-none rounded-full"
+      class="dark:bg-transparent focus:ring-transparent focus:ring-offset-0 dark:focus:bg-transparent peer flex-grow block min-w-0 p-0 bg-transparent border-none"
       :placeholder="$i18n.t('tasks.addPlaceholder')"
       @keyup="checkEnter"
     >

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -400,7 +400,8 @@ export default {
   tasks: {
     title: 'Tasks',
     empty: 'No tasks yet',
-    manage: 'Manage'
+    manage: 'Manage',
+    addPlaceholder: 'Enter something you need to do'
   },
   ready: 'Done',
   errorpage: {

--- a/i18n/hu.js
+++ b/i18n/hu.js
@@ -405,7 +405,8 @@ export default {
   tasks: {
     title: 'Feladatok',
     empty: 'Nincs felvett teendő',
-    manage: 'Kezelés'
+    manage: 'Kezelés',
+    addPlaceholder: 'Írj be egy új teendőt'
   },
   ready: 'Kész',
   errorpage: {


### PR DESCRIPTION
The text field for adding a new task now has a placeholder to help the user more easily identify what it is for. Note that for now contrast was not changed since the placeholder text (hopefully) already improves it.

Closes #176 

![tasksplaceholder](https://user-images.githubusercontent.com/18259108/163392596-30aae214-5265-4086-ae38-e47579a63474.png)
