### PR TITLE
feat(tasks): Editable task titles

### DIFF
--- a/components/todoList/item.vue
+++ b/components/todoList/item.vue
@@ -32,10 +32,10 @@
 
     <span class="flex-grow" />
 
-    <div class="flex flex-row items-center flex-shrink-0 space-x-1">
+    <div class="md:gap-3 flex flex-row items-center flex-shrink-0 gap-4">
       <transition name="slidein">
-        <button v-show="manage" class="transition-all duration-100" @click="$emit('delete')">
-          <IconDelete size="18" class="mr-1" />
+        <button v-show="manage" class="hover:bg-slate-900 dark:hover:bg-slate-100 hover:bg-opacity-10 dark:hover:bg-opacity-20 md:p-2 md:-m-2 p-3 -m-3 transition-all duration-100 rounded-full" @click="$emit('delete')">
+          <IconDelete size="18" />
         </button>
       </transition>
       <input :checked="checked" type="checkbox" class="themed-checkbox md:w-5 md:h-5 w-6 h-6 mr-1 rounded" @input="checked = !checked">

--- a/components/todoList/item.vue
+++ b/components/todoList/item.vue
@@ -108,7 +108,6 @@ export default {
     editing (newValue) {
       if (newValue) {
         this.$nextTick(() => {
-          console.log(`Editing -> focus on ${this.$refs.editbox}`)
           this.$refs.editbox?.focus()
         })
       }
@@ -125,7 +124,6 @@ export default {
 
     handleEdit (newValue) {
       if (this.valid && this.item.title !== this.displayedTitle) {
-        console.log(`Updated task to ${newValue}`)
         this.$emit('update', newValue)
       }
       this.editedTitle = null

--- a/components/todoList/item.vue
+++ b/components/todoList/item.vue
@@ -1,6 +1,7 @@
 <template>
   <div
-    :class="['relative bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 hover:shadow-sm rounded-md border-l-8 themed-border px-2 py-3 md:py-2 transition-all duration-200 flex flex-row items-center', { 'opacity-50 line-through italic': item.state === 2, 'cursor-move': showReorder, 'ring themed-ring': dragged || droptarget }]"
+    class="hover:shadow-sm themed-border md:py-2 relative flex flex-row items-center px-2 py-3 transition-all duration-200 border-l-8 rounded-md"
+    :class="[{ 'opacity-50 line-through italic': item.state === 2, 'cursor-move': showReorder, 'ring themed-ring': dragged || droptarget, 'themed-bg': manage && editing }, manage && editing ? 'themed-bg' : 'bg-gray-100 dark:bg-gray-700 hover:bg-gray-200']"
     :style="{ '--theme': $store.state.settings.visuals[item.section].colour }"
     draggable
     @mouseenter="hovering = true"
@@ -21,8 +22,9 @@
         v-if="manage && editing"
         ref="editbox"
         v-model="displayedTitle"
-        class="break-words bg-transparent"
+        class="py-2 pl-1 -my-2 -ml-1 bg-transparent outline-none"
         @blur="editing = false, handleEdit(displayedTitle)"
+        @keyup.enter.exact="editing = false, handleEdit(displayedTitle)"
       >
       <span v-else class="break-words">{{ item.title }}</span>
       <!-- <span class="text-sm">Description</span> -->
@@ -70,7 +72,7 @@ export default {
     return {
       hovering: false,
       dragged: false,
-      editing: true,
+      editing: false,
       editedTitle: null
     }
   },
@@ -85,12 +87,12 @@ export default {
     },
     showReorder: {
       get () {
-        return this.moveable && this.hovering
+        return this.editing || (this.moveable && this.hovering)
       }
     },
     valid: {
       get () {
-        return !this.$store.state.tasklist.tasks.some(task => task.id !== this.item.id && task.title === this.item.title && task.section === this.item.section)
+        return !this.$store.state.tasklist.tasks.some(task => task.id !== this.item.id && task.title === this.displayedTitle && task.section === this.item.section)
       }
     },
     displayedTitle: {
@@ -122,10 +124,11 @@ export default {
     },
 
     handleEdit (newValue) {
-      if (this.valid) {
+      if (this.valid && this.item.title !== this.displayedTitle) {
         console.log(`Updated task to ${newValue}`)
         this.$emit('update', newValue)
       }
+      this.editedTitle = null
     }
   }
 }

--- a/components/todoList/item.vue
+++ b/components/todoList/item.vue
@@ -44,11 +44,11 @@
 </template>
 
 <script>
-import { MenuIcon, EraserIcon, PencilIcon } from 'vue-tabler-icons'
+import { MenuIcon, TrashIcon, PencilIcon } from 'vue-tabler-icons'
 import { taskState } from '@/store/tasklist'
 
 export default {
-  components: { IconMenu: MenuIcon, IconDelete: EraserIcon, IconEditing: PencilIcon },
+  components: { IconMenu: MenuIcon, IconDelete: TrashIcon, IconEditing: PencilIcon },
   props: {
     item: {
       type: Object,

--- a/components/todoList/item.vue
+++ b/components/todoList/item.vue
@@ -107,6 +107,7 @@ export default {
   watch: {
     editing (newValue) {
       if (newValue) {
+        // only focus on <input> in the next tick (when it is rendered)
         this.$nextTick(() => {
           this.$refs.editbox?.focus()
         })

--- a/components/todoList/item.vue
+++ b/components/todoList/item.vue
@@ -22,7 +22,7 @@
         v-if="manage && editing"
         ref="editbox"
         v-model="displayedTitle"
-        class="py-2 pl-1 -my-2 -ml-1 bg-transparent outline-none"
+        class="py-2 pl-1 -my-2 -ml-1 text-white bg-transparent outline-none"
         @blur="editing = false, handleEdit(displayedTitle)"
         @keyup.enter.exact="editing = false, handleEdit(displayedTitle)"
       >

--- a/components/todoList/item.vue
+++ b/components/todoList/item.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="hover:shadow-sm themed-border md:py-2 relative flex flex-row items-center px-2 py-3 transition-all duration-200 border-l-8 rounded-md"
-    :class="[{ 'opacity-50 line-through italic': item.state === 2, 'cursor-move': showReorder, 'ring themed-ring': dragged || droptarget, 'themed-bg': manage && editing }, manage && editing ? 'themed-bg' : 'bg-gray-100 dark:bg-gray-700 hover:bg-gray-200']"
+    :class="[{ 'opacity-50 line-through italic': item.state === 2, 'cursor-move': showReorder, 'ring themed-ring': dragged || droptarget, 'themed-bg !text-white': manage && editing }, manage && editing ? 'themed-bg' : 'bg-gray-100 dark:bg-gray-700 hover:bg-gray-200']"
     :style="{ '--theme': $store.state.settings.visuals[item.section].colour }"
     draggable
     @mouseenter="hovering = true"

--- a/components/todoList/main.vue
+++ b/components/todoList/main.vue
@@ -26,6 +26,7 @@
         :droptarget="task === dropTarget"
         moveable
         @input="$store.commit('tasklist/toggleComplete', { item: task })"
+        @update="newTitle => $store.commit('tasklist/editTitle', { id: task.id, newTitle })"
         @delete="$store.commit('tasklist/delete', { item: task })"
         @dropstart="draggedItem = task, dragging = true"
         @dropfinish="handleDrop"

--- a/components/todoList/main.vue
+++ b/components/todoList/main.vue
@@ -7,7 +7,7 @@
         <IconManage class="inline translate-y-[-0.1rem]" size="16" />
         <span v-text="$i18n.t('tasks.manage')" />
       </button> -->
-      <button class="hover:bg-gray-300 active:bg-gray-400 absolute right-0 float-right p-2 transition-all rounded-full" @click="$emit('hide')">
+      <button class="hover:bg-gray-300 dark:hover:bg-gray-700 active:bg-gray-400 absolute right-0 float-right p-2 transition-all rounded-full" @click="$emit('hide')">
         <XIcon />
       </button>
     </div>

--- a/components/todoList/main.vue
+++ b/components/todoList/main.vue
@@ -20,7 +20,7 @@
     >
       <TaskItem
         v-for="task in displayedTasks"
-        :key="task.section + '-' + task.title"
+        :key="task.id"
         :manage="!$store.getters['schedule/isRunning'] && manageMode"
         :item="task"
         :droptarget="task === dropTarget"

--- a/store/tasklist.js
+++ b/store/tasklist.js
@@ -26,7 +26,8 @@ export const mutations = {
       priority,
       section,
       state,
-      keepOnScreen: false
+      keepOnScreen: false,
+      id: currentState.tasks.reduce((lastMax, currentItem) => Math.max(currentItem.id ?? 0, lastMax), -1) + 1
     }
 
     currentState.tasks.push(newTask)

--- a/store/tasklist.js
+++ b/store/tasklist.js
@@ -72,5 +72,13 @@ export const mutations = {
     if (oldIndex < 0 || newIndex >= state.tasks.length) { return }
 
     state.tasks.splice(newIndex, 0, state.tasks.splice(oldIndex, 1)[0])
+  },
+
+  editTitle (state, { id, newTitle }) {
+    const taskIndex = state.tasks.findIndex(item => item.id === id)
+
+    if (taskIndex < 0) { return }
+
+    state.tasks[taskIndex].title = newTitle
   }
 }


### PR DESCRIPTION
Tasks can now be renamed by clicking on them. This PR also improves the user experience of the tasks panel by:

- reverting the delete icon to trashcan
- enlarging the click area of the task delete button 
- making the task panel's close button less bright in dark mode

Closes #174 

![Screenshot of a task being edited](https://user-images.githubusercontent.com/18259108/164980728-a78bc6c1-feb5-47f8-bf94-fdbbce24e1b8.png)

