### PR TITLE
chore(i18n): Fix time format string in translation source

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -242,7 +242,7 @@
           "percentage": "Percentage"
         },
         "_valueDescription": {
-          "traditional": "12: 34",
+          "traditional": "12:34",
           "approximate": "13 minutes",
           "percentage": "50%"
         }


### PR DESCRIPTION
This PR fixes a time format string in the English translations (it changed during the JSON format conversion).