### PR TITLE
feat: Add ability to save and restore settings and tasks

### DIFF
--- a/components/settings/exportButton.vue
+++ b/components/settings/exportButton.vue
@@ -1,16 +1,12 @@
 <template>
-  <Button @click="downloadSettings">
-    Export
-  </Button>
+  <button class="px-4 py-3 transition border-2 border-red-400 rounded-full select-none dark:shadow-none hover:bg-red-400 active:bg-red-500 active:border-red-500 active:shadow-red-200 active:shadow-md" @click="downloadSettings" v-text="$i18n.t('settings.manage.buttons.save')" />
 </template>
 
 <script>
-import Button from '@/components/base/button.vue'
 import { useSettings } from '@/stores/settings'
 import { useTasklist } from '@/stores/tasklist'
 
 export default {
-  components: { Button },
   methods: {
     downloadSettings () {
       const settings = useSettings().$state

--- a/components/settings/exportButton.vue
+++ b/components/settings/exportButton.vue
@@ -1,0 +1,34 @@
+<template>
+  <Button @click="downloadSettings">
+    Export
+  </Button>
+</template>
+
+<script>
+import Button from '@/components/base/button.vue'
+import { useSettings } from '@/stores/settings'
+import { useTasklist } from '@/stores/tasklist'
+
+export default {
+  components: { Button },
+  methods: {
+    downloadSettings () {
+      const settings = useSettings().$state
+      const tasklist = useTasklist().$state
+
+      const downloadObject = {
+        settings,
+        tasklist
+      }
+
+      const downloadElement = document.createElement('a')
+      downloadElement.href = `data:text/plain;charset=utf-8,${encodeURIComponent(JSON.stringify(downloadObject))}`
+      downloadElement.download = 'anotherpomodoro-settings.json'
+      downloadElement.style.display = 'none'
+      document.body.appendChild(downloadElement)
+      downloadElement.click()
+      document.body.removeChild(downloadElement)
+    }
+  }
+}
+</script>

--- a/components/settings/importButton.vue
+++ b/components/settings/importButton.vue
@@ -1,0 +1,46 @@
+<template>
+  <Button @click="openFileDialog">
+    <input ref="fileinput" accept=".json" type="file" hidden @change="importFile">
+    Import
+  </Button>
+</template>
+
+<script>
+import Button from '@/components/base/button.vue'
+import { useSettings } from '~/stores/settings'
+import { useTasklist } from '~/stores/tasklist'
+
+export default {
+  components: { Button },
+
+  methods: {
+    openFileDialog () {
+      this.$refs.fileinput.click()
+    },
+
+    importFile () {
+      // try to get file from the input field
+      const file = this.$refs.fileinput.files[0]
+      if (!file) {
+        return
+      }
+
+      // read file
+      const reader = new FileReader()
+      reader.onload = (e) => {
+        const fileContents = e.target.result
+
+        // try to patch settings and task list with the imported values
+        try {
+          const importedValues = JSON.parse(fileContents)
+          useSettings().$patch(importedValues.settings)
+          useTasklist().$patch(importedValues.tasklist)
+        } catch (err) {
+          console.warn(err)
+        }
+      }
+      reader.readAsText(file)
+    }
+  }
+}
+</script>

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -43,7 +43,7 @@
               <Divider />
 
               <div v-text="$i18n.t('settings.manage.heading')" />
-              <div class="-mt-2 text-sm text-black text-opacity-75 dark:text-gray-50 dark:text-opacity-75" v-text="$i18n.t('settings.manage.description')" />
+              <div class="-mt-2 text-sm leading-snug text-black text-opacity-75 dark:text-gray-50 dark:text-opacity-75" v-text="$i18n.t('settings.manage.description')" />
               <div class="grid grid-flow-col grid-cols-2 gap-2 mt-1">
                 <ExportButton />
                 <ImportButton />

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -42,8 +42,12 @@
 
               <Divider />
 
-              <ExportButton />
-              <ImportButton />
+              <div v-text="$i18n.t('settings.manage.heading')" />
+              <div class="-mt-2 text-sm text-black text-opacity-75 dark:text-gray-50 dark:text-opacity-75" v-text="$i18n.t('settings.manage.description')" />
+              <div class="grid grid-flow-col grid-cols-2 gap-2 mt-1">
+                <ExportButton />
+                <ImportButton />
+              </div>
 
               <Divider />
 

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -1,6 +1,6 @@
 <template>
-  <section v-show="processedValue" class="md:p-4 md:max-w-screen-sm fixed z-40 w-full h-full p-0">
-    <div class="md:rounded-lg dark:bg-gray-900 dark:text-gray-50 flex flex-col h-full overflow-hidden bg-white rounded-none shadow-lg">
+  <section v-show="processedValue" class="fixed z-40 w-full h-full p-0 md:p-4 md:max-w-screen-sm">
+    <div class="flex flex-col h-full overflow-hidden bg-white rounded-none shadow-lg md:rounded-lg dark:bg-gray-900 dark:text-gray-50">
       <h1 class="px-4 mt-4 mb-2 text-xl font-bold uppercase">
         <span>{{ $i18n.t('settings.heading') }}</span>
         <UiButton :aria-label="$i18n.t('settings.buttons.close')" subtle class="float-right -mt-2 -mr-2" tabindex="0" @click="processedValue = false">
@@ -42,6 +42,11 @@
 
               <Divider />
 
+              <ExportButton />
+              <ImportButton />
+
+              <Divider />
+
               <SettingsCheck :settings-key="['reset']" />
             </div>
 
@@ -60,7 +65,7 @@
               <SettingsTime :settings-key="['schedule', 'lengths', 'work']" :min-ms="5000" />
               <SettingsTime :settings-key="['schedule', 'lengths', 'shortpause']" :min-ms="5000" />
               <SettingsTime :settings-key="['schedule', 'lengths', 'longpause']" :min-ms="5000" />
-              <div class="ring-inset ring ring-primary bg-primary/20 dark:bg-gray-700 dark:text-gray-100 flex flex-row items-center px-3 py-4 space-x-2 rounded-lg">
+              <div class="flex flex-row items-center px-3 py-4 space-x-2 rounded-lg ring-inset ring ring-primary bg-primary/20 dark:bg-gray-700 dark:text-gray-100">
                 <InfoIcon />
                 <span v-text="$i18n.t('settings.scheduleMinTime')" />
               </div>
@@ -99,11 +104,11 @@
                 <div class="flex flex-col items-center justify-center mt-8">
                   <!-- Support links -->
                   <div class="flex flex-row mt-3 space-x-2 text-center">
-                    <a href="https://www.github.com/Hanziness/AnotherPomodoro?utm_source=AnotherPomodoro&utm_medium=web&utm_content=settings" class="hover:bg-gray-700 active:bg-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600 dark:active:bg-gray-800 flex flex-row items-center px-4 py-2 space-x-1 text-white transition-colors bg-black rounded-full">
+                    <a href="https://www.github.com/Hanziness/AnotherPomodoro?utm_source=AnotherPomodoro&utm_medium=web&utm_content=settings" class="flex flex-row items-center px-4 py-2 space-x-1 text-white transition-colors bg-black rounded-full hover:bg-gray-700 active:bg-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600 dark:active:bg-gray-800">
                       <AboutGithub />
                       <span v-text="$i18n.t('settings.about.source')" />
                     </a>
-                    <a href="https://www.buymeacoffee.com/imreg?utm_source=AnotherPomodoro&utm_medium=web&utm_content=settings" class="hover:bg-yellow-200 active:bg-yellow-400 flex flex-row items-center px-4 py-2 space-x-1 text-black transition-colors bg-yellow-300 rounded-full">
+                    <a href="https://www.buymeacoffee.com/imreg?utm_source=AnotherPomodoro&utm_medium=web&utm_content=settings" class="flex flex-row items-center px-4 py-2 space-x-1 text-black transition-colors bg-yellow-300 rounded-full hover:bg-yellow-200 active:bg-yellow-400">
                       <AboutSupport />
                       <span v-text="$i18n.t('settings.about.support')" />
                     </a>
@@ -161,6 +166,8 @@ import { XIcon, AdjustmentsIcon, AlarmIcon, ArtboardIcon, InfoCircleIcon, BrandG
 import { mapActions, mapState, mapStores } from 'pinia'
 import OptionGroup from '@/components/base/optionGroup.vue'
 import TabHeader from '@/components/settings/panel/tabHeader.vue'
+import ExportButton from '@/components/settings/exportButton.vue'
+import ImportButton from '@/components/settings/importButton.vue'
 
 import presetTimers from '@/assets/settings/timerPresets'
 import { useSettings } from '~/stores/settings'
@@ -179,6 +186,8 @@ export default {
     Divider: () => import(/* webpackMode: "eager" */ '@/components/base/divider.vue'),
     OptionGroup,
     TabHeader,
+    ExportButton,
+    ImportButton,
     CloseIcon: XIcon,
     // ResetIcon: RefreshAlertIcon,
     TabIconGeneral: AdjustmentsIcon,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -217,6 +217,14 @@
       "confirm": "Reset",
       "cancel": "Cancel"
     },
+    "manage": {
+      "heading": "Manage settings",
+      "description": "Download the current settings or load them from a file",
+      "buttons": {
+        "save": "Save",
+        "load": "Load"
+      }
+    },
     "scheduleMinTime": "The minimum allowed time is 5 seconds",
     "about": {
       "madeby": "Made by Imre Gera",


### PR DESCRIPTION
Two new buttons are added to the "Main" tab of the settings that allow the user to download their current settings and tasks into a JSON file and then later restore a configuration from a file.

The export/import options are not customizable: the whole settings and task list stores are saved and restored.

![New settings export/import buttons](https://user-images.githubusercontent.com/18259108/169893885-2c7d64d8-0858-42af-8685-80c989a099a1.png)
