### PR TITLE
feat: Continue tracking time after timer expired

### DIFF
--- a/components/ticker.vue
+++ b/components/ticker.vue
@@ -9,7 +9,7 @@ export default {
   data () {
     return {
       // timeOriginal: 1,
-      timeElapsed: 0,
+      // timeElapsed: 0,
       lastUpdate: new Date().getTime(),
       nextTickDelta: 1000,
       timerHandle: null
@@ -27,6 +27,15 @@ export default {
     }),
 
     ...mapWritableState(useSchedule, ['timerState']),
+
+    timeElapsed: {
+      get () {
+        return useSchedule().items[0].timeElapsed
+      },
+      set (newValue) {
+        useSchedule().items[0].timeElapsed = newValue
+      }
+    },
 
     timeRemaining () {
       return this.timeOriginal - this.timeElapsed

--- a/components/timer/controls/contolsBasic.vue
+++ b/components/timer/controls/contolsBasic.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="w-max dark:text-gray-100 z-10 flex flex-row items-center p-2 text-gray-900 bg-transparent">
+  <div class="z-10 flex flex-row items-center p-2 text-gray-900 bg-transparent w-max dark:text-gray-100">
     <!-- Reset -->
     <div
       role="button"
-      class="dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-600 active:bg-gray-400 dark:active:bg-gray-500 -z-20 py-3 pl-4 pr-5 -mr-2 text-lg transition-colors bg-gray-200 rounded-l-lg shadow-md cursor-pointer"
+      class="py-3 pl-4 pr-5 -mr-2 text-lg transition-colors bg-gray-200 rounded-l-lg shadow-md cursor-pointer dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-600 active:bg-gray-400 dark:active:bg-gray-500 -z-20"
       :class="[{ 'pointer-events-none': !resetEnabled }]"
       :aria-disabled="!resetEnabled"
       :aria-label="$i18n.t('controls.stop')"
@@ -15,7 +15,7 @@
 
     <!-- Play/pause -->
     <div
-      class="dark:bg-gray-800 active:bg-gray-300 dark:active:bg-gray-700 play-button relative p-4 text-xl transition-colors bg-gray-200 rounded-full shadow-xl cursor-pointer"
+      class="relative p-4 text-xl transition-colors bg-gray-200 rounded-full shadow-xl cursor-pointer dark:bg-gray-800 active:bg-gray-300 dark:active:bg-gray-700 play-button"
       role="button"
       :aria-label="$i18n.t('controls.play')"
       tabindex="0"
@@ -40,7 +40,7 @@
       role="button"
       :aria-label="$i18n.t('controls.advance')"
       :aria-disabled="!advanceEnabled"
-      class="dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-600 active:bg-gray-400 dark:active:bg-gray-500 -z-20 py-3 pl-5 pr-4 -ml-2 text-lg transition-colors bg-gray-200 rounded-r-lg shadow-md cursor-pointer"
+      class="py-3 pl-5 pr-4 -ml-2 text-lg transition-colors bg-gray-200 rounded-r-lg shadow-md cursor-pointer dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-600 active:bg-gray-400 dark:active:bg-gray-500 -z-20"
       :class="[{ 'pointer-events-none': !advanceEnabled }]"
       tabindex="0"
       @click="advance"
@@ -97,14 +97,14 @@ export default {
       // move to next section if timer is completed
       if (this.scheduleStore.getCurrentTimerState === TimerState.COMPLETED) {
         this.advance()
-        this.scheduleStore.timerState = TimerState.TICKING
+        this.scheduleStore.timerState = TimerState.RUNNING
       } else {
-        this.scheduleStore.timerState = this.scheduleStore.getCurrentTimerState !== TimerState.TICKING ? TimerState.TICKING : TimerState.PAUSED
+        this.scheduleStore.timerState = this.scheduleStore.getCurrentTimerState !== TimerState.RUNNING ? TimerState.RUNNING : TimerState.PAUSED
       }
     },
 
     reset () {
-      this.scheduleStore.timerState = TimerState.RESET
+      this.scheduleStore.timerState = TimerState.STOPPED
     },
 
     advance () {

--- a/components/timer/controls/contolsBasic.vue
+++ b/components/timer/controls/contolsBasic.vue
@@ -10,7 +10,14 @@
       tabindex="0"
       @click="reset"
     >
-      <IconStop :aria-label="$i18n.t('controls.stop')" class="transition-opacity duration-300" :class="[{ 'opacity-40': !resetEnabled }]" size="24" :title="$i18n.t('controls.stop')" />
+      <Component
+        :is="stopResetIcon"
+        :aria-label="$i18n.t('controls.stop')"
+        class="transition-opacity duration-300"
+        :class="[{ 'opacity-40': !resetEnabled }]"
+        size="24"
+        :title="$i18n.t('controls.stop')"
+      />
     </div>
 
     <!-- Play/pause -->
@@ -51,7 +58,7 @@
 </template>
 
 <script>
-import { PlayerPlayIcon, PlayerPauseIcon, PlayerStopIcon, PlayerSkipForwardIcon } from 'vue-tabler-icons'
+import { PlayerPlayIcon, PlayerPauseIcon, PlayerStopIcon, PlayerSkipForwardIcon, PlayerSkipBackIcon } from 'vue-tabler-icons'
 import { mapStores } from 'pinia'
 import KeyboardListener from '@/assets/mixins/keyboardListener'
 
@@ -64,7 +71,8 @@ export default {
     IconPlay: PlayerPlayIcon,
     IconPause: PlayerPauseIcon,
     IconStop: PlayerStopIcon,
-    IconSkipNext: PlayerSkipForwardIcon
+    IconSkipNext: PlayerSkipForwardIcon,
+    IconReset: PlayerSkipBackIcon
   },
 
   mixins: [KeyboardListener],
@@ -82,6 +90,16 @@ export default {
 
     advanceEnabled () {
       return this.scheduleStore.getCurrentTimerState !== TimerState.RUNNING
+    },
+
+    stopResetIcon () {
+      const elapsed = this.scheduleStore.items[0].timeElapsed
+      const total = this.scheduleStore.items[0].length
+      if (elapsed >= total && this.scheduleStore.isRunning) {
+        return PlayerStopIcon
+      }
+
+      return PlayerSkipBackIcon
     }
   },
 

--- a/components/timer/controls/contolsBasic.vue
+++ b/components/timer/controls/contolsBasic.vue
@@ -77,11 +77,11 @@ export default {
     },
 
     resetEnabled () {
-      return this.scheduleStore.getCurrentTimerState !== 0
+      return this.scheduleStore.getCurrentTimerState !== TimerState.STOPPED
     },
 
     advanceEnabled () {
-      return this.scheduleStore.getCurrentTimerState !== 1
+      return this.scheduleStore.getCurrentTimerState !== TimerState.RUNNING
     }
   },
 
@@ -104,11 +104,16 @@ export default {
     },
 
     reset () {
-      this.scheduleStore.timerState = TimerState.STOPPED
+      if (this.scheduleStore.timerState !== TimerState.COMPLETED && this.scheduleStore.items[0].timeElapsed > this.scheduleStore.items[0].length) {
+        this.scheduleStore.timerState = TimerState.COMPLETED
+      } else {
+        this.scheduleStore.timerState = TimerState.STOPPED
+      }
     },
 
     advance () {
       this.scheduleStore.advance()
+      this.scheduleStore.timerState = TimerState.STOPPED
     }
   }
 }

--- a/components/timer/display/_timerSwitch.vue
+++ b/components/timer/display/_timerSwitch.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="dark:text-gray-100 relative flex flex-col justify-center text-center text-black transition-opacity duration-500 select-none" :class="[{ 'opacity-70': !running, 'opacity-100': running }]">
+  <div class="relative flex flex-col justify-center text-center text-black transition-opacity duration-500 select-none dark:text-gray-100" :class="[{ 'opacity-70': !running, 'opacity-100': running }]">
     <Transition name="timer-switch" mode="out-in">
-      <CompleteMarker v-if="getCurrentTimerState === 3" :key="'complete'" />
+      <CompleteMarker v-if="getCurrentTimerState === timerStates.COMPLETED" :key="'complete'" />
       <TimerTraditional v-else-if="timerWidget === 'traditional'" v-bind="timerInfo" :key="'traditional'" @tick="$emit('tick', $event)" />
       <TimerApproximate v-else-if="timerWidget === 'approximate'" v-bind="timerInfo" :key="'approximate'" @tick="$emit('tick', $event)" />
       <TimerPercentage v-else-if="timerWidget === 'percentage'" v-bind="timerInfo" :key="'percentage'" @tick="$emit('tick', $event)" />
@@ -13,7 +13,7 @@
 import { mapState } from 'pinia'
 import { AvailableTimers } from '@/stores/settings'
 import TimerMixin from '@/assets/mixins/timerMixin'
-import { useSchedule } from '~/stores/schedule'
+import { useSchedule, TimerState } from '~/stores/schedule'
 
 export default {
   components: {
@@ -30,6 +30,11 @@ export default {
       validator (value) {
         return Object.values(AvailableTimers).includes(value)
       }
+    }
+  },
+  data () {
+    return {
+      timerStates: TimerState
     }
   },
   computed: {

--- a/components/timer/display/timerApproximate.vue
+++ b/components/timer/display/timerApproximate.vue
@@ -1,12 +1,17 @@
 <template>
-  <div :class="['timer-display select-none flex flex-row gap-2 items-center leading-none', { 'active': running }]">
-    <transition name="transition-approximate-up" mode="out-in">
-      <div :key="time.value" :style="{ '--ch': Math.ceil(Math.log10(time.value + 1)) }" class="text-9xl xl:text-[12rem] font-bold text-right time-value">
-        {{ time.value }}
+  <div :class="['timer-display select-none flex flex-row gap-2 items-center leading-none text-9xl xl:text-[12rem]', { 'active': running }]">
+    <transition>
+      <div v-show="time.value < 0" class="-mr-4 font-bold">
+        +
       </div>
     </transition>
     <transition name="transition-approximate-up" mode="out-in">
-      <div :key="time.string" class="text-3xl xl:text-7xl">
+      <div :key="time.value" :style="{ '--ch': Math.max(1, Math.ceil(Math.log10(Math.abs(time.value) + 1))) }" class="font-bold text-right time-value">
+        {{ Math.abs(time.value) }}
+      </div>
+    </transition>
+    <transition name="transition-approximate-up" mode="out-in">
+      <div :key="time.string" class="text-[.5em]">
         {{ time.string }}
       </div>
     </transition>
@@ -34,7 +39,7 @@ export default {
         timeObject.string = this.$i18n.tc('timer.approximate.minutes', timeObject.value)
       }
 
-      this.$emit('tick', `${timeObject.value} ${timeObject.string}`)
+      this.$emit('tick', `${timeObject.value < 0 ? '+' : ''}${Math.abs(timeObject.value)} ${timeObject.string}`)
       return timeObject
     }
   }

--- a/components/timer/display/timerApproximate.vue
+++ b/components/timer/display/timerApproximate.vue
@@ -1,15 +1,17 @@
 <template>
-  <div :class="['timer-display select-none flex flex-row gap-2 items-center leading-none text-9xl xl:text-[12rem]', { 'active': running }]">
-    <transition>
-      <div v-show="time.value < 0" class="-mr-4 font-bold">
-        +
-      </div>
-    </transition>
-    <transition name="transition-approximate-up" mode="out-in">
-      <div :key="time.value" :style="{ '--ch': Math.max(1, Math.ceil(Math.log10(Math.abs(time.value) + 1))) }" class="font-bold text-right time-value">
-        {{ Math.abs(time.value) }}
-      </div>
-    </transition>
+  <div :class="['timer-display select-none flex flex-col md:flex-row gap-2 items-center leading-none text-9xl xl:text-[12rem]', { 'active': running }]">
+    <div class="flex flex-row">
+      <transition name="transition-approximate-up">
+        <div v-show="time.value < 0" class="-mr-2 font-bold">
+          +
+        </div>
+      </transition>
+      <transition name="transition-approximate-up" mode="out-in">
+        <div :key="time.value" :style="{ '--ch': Math.max(1, Math.ceil(Math.log10(Math.abs(time.value) + 1))) }" class="font-bold text-center md:text-right time-value">
+          {{ Math.abs(time.value) }}
+        </div>
+      </transition>
+    </div>
     <transition name="transition-approximate-up" mode="out-in">
       <div :key="time.string" class="text-[.5em]">
         {{ time.string }}

--- a/components/timer/display/timerApproximate.vue
+++ b/components/timer/display/timerApproximate.vue
@@ -37,7 +37,7 @@ export default {
         timeObject.value = remainingMinutes >= 0 ? Math.round(remainingMinutes / 60) : Math.ceil(remainingMinutes / 60)
         timeObject.string = this.$i18n.tc('timer.approximate.hours', timeObject.value)
       } else {
-        timeObject.value = remainingMinutes >= 0 ? Math.ceil(remainingMinutes) : Math.floor(remainingMinutes)
+        timeObject.value = remainingMinutes > 0 ? Math.ceil(remainingMinutes) : Math.min(-1, Math.floor(remainingMinutes))
         timeObject.string = this.$i18n.tc('timer.approximate.minutes', timeObject.value)
       }
 

--- a/components/timer/display/timerApproximate.vue
+++ b/components/timer/display/timerApproximate.vue
@@ -33,11 +33,11 @@ export default {
         value: 0,
         string: null
       }
-      if (remainingMinutes > 59) {
-        timeObject.value = Math.round(remainingMinutes / 60)
+      if (Math.abs(remainingMinutes) > 59) {
+        timeObject.value = remainingMinutes >= 0 ? Math.round(remainingMinutes / 60) : Math.ceil(remainingMinutes / 60)
         timeObject.string = this.$i18n.tc('timer.approximate.hours', timeObject.value)
       } else {
-        timeObject.value = Math.ceil(remainingMinutes)
+        timeObject.value = remainingMinutes >= 0 ? Math.ceil(remainingMinutes) : Math.floor(remainingMinutes)
         timeObject.string = this.$i18n.tc('timer.approximate.minutes', timeObject.value)
       }
 

--- a/components/timer/display/timerTraditional.vue
+++ b/components/timer/display/timerTraditional.vue
@@ -1,28 +1,32 @@
 <template>
   <div
-    :class="['flex flex-row gap-0 md:text-[14rem] text-[9rem] leading-none timer-display relative', { 'active': running }]"
+    :class="['md:text-[14rem] text-[9rem] leading-none timer-display relative', { 'active': running }]"
   >
     <transition-group
       name="transition-traditional"
-      enter-class="translate-x-4 opacity-0"
+      enter-class="translate-y-4 opacity-0 md:translate-y-0 md:translate-x-4"
       enter-active-class="duration-500"
       enter-to-class=""
       leave-class=""
-      leave-active-class="duration-300 absolute"
-      leave-to-class="opacity-0"
+      leave-active-class="absolute duration-300"
+      leave-to-class="opacity-0 md:-translate-x-8"
       move-class="duration-500"
-      class="flex flex-col items-center md:flex-row"
+      class="relative flex flex-col items-center transition md:flex-row isolate"
       tag="div"
+      @beforeLeave="beforeLeave"
     >
       <div
         v-for="key in timeLeftStructured.displayKeys"
         :key="key"
-        class="transition flex flex-row"
+        class="flex flex-row transition"
         :class="{ 'font-bold': key === 'minutes', 'md:text-9xl md:self-start': key === 'seconds', 'md:mr-4': key === 'hours' }"
-        tag="div"
       >
+        <div v-if="key === '_plus'" class="font-bold text-[.75em]">
+          +
+        </div>
         <span
           v-for="(char, idx) in timeLeftStructured.num[key].toString().padStart(2, '0')"
+          v-else
           :key="`${key}-${idx}`"
           class="w-[1ch]"
           :class="{ 'md:text-right text-center': idx === 0, 'md:text-left text-center': idx === 1 }"
@@ -40,23 +44,38 @@ export default {
   mixins: [TimerMixin],
   computed: {
     timeLeftStructured () {
-      const sLeft = Math.round((this.timeOriginal - this.timeElapsed) / 1000)
+      const sLeft = Math.abs(Math.round((this.timeOriginal - this.timeElapsed) / 1000))
       const hours = Math.floor(sLeft / (60 * 60))
       const minutes = Math.floor((sLeft % (60 * 60)) / (60))
       const seconds = Math.floor(sLeft % 60)
 
+      const displayKeys = ['hours', 'minutes', 'seconds'].filter(value => value !== 'hours' || hours > 0)
+      const completed = this.timeElapsed > this.timeOriginal && [hours, minutes, seconds].some(num => num > 0)
+
+      if (completed) {
+        displayKeys.unshift('_plus')
+      }
+
       const returnObject = {
         num: { hours, minutes, seconds },
-        displayKeys: ['hours', 'minutes', 'seconds'].filter(value => value !== 'hours' || hours > 0)
+        displayKeys,
+        completed
       }
 
       this.$emit(
         'tick',
-        returnObject.displayKeys
+        (completed ? '+' : '') + displayKeys
+          .filter(key => !key.startsWith('_'))
           .map(key => returnObject.num[key].toString().padStart(2, '0'))
           .join(':')
       )
       return returnObject
+    }
+  },
+  methods: {
+    /** "Hack" used to get around object flying in from the corners of the page */
+    beforeLeave (el) {
+
     }
   }
 }

--- a/components/timer/timerProgress.vue
+++ b/components/timer/timerProgress.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="transform-gpu absolute top-0 left-0 block w-full h-full transition-all duration-500"
+    class="absolute top-0 left-0 block w-full h-full transition-all duration-500 transform-gpu"
     :class="[{ 'ease-out-expo': background }]"
     :style="{
       'background-color': colour ? colour : getScheduleColour[scheduleEntryId],
@@ -8,7 +8,7 @@
     }"
   >
     <!-- Dark mode background override -->
-    <div class="dark:visible mix-blend-multiply absolute invisible w-full h-full bg-gray-600" />
+    <div class="absolute invisible w-full h-full bg-gray-600 dark:visible mix-blend-multiply" />
   </div>
 </template>
 
@@ -43,7 +43,7 @@ export default {
     ...mapState(useSchedule, ['getScheduleColour']),
 
     progressPercentage () {
-      return (this.timeElapsed / this.timeOriginal) * 100
+      return Math.min((this.timeElapsed / this.timeOriginal) * 100, 100)
     }
   }
 }

--- a/stores/schedule.js
+++ b/stores/schedule.js
@@ -4,7 +4,7 @@ import { useSettings } from './settings'
 export const useSchedule = defineStore('schedule', {
   state: () => ({
     items: createScheduleSeries(10),
-    timerState: TIMERSTATE.STOPPED
+    timerState: TimerState.STOPPED
   }),
 
   getters: {
@@ -79,7 +79,7 @@ export const useSchedule = defineStore('schedule', {
     },
 
     isRunning: (state) => {
-      return [TIMERSTATE.RUNNING, TIMERSTATE.PAUSED].includes(state.timerState)
+      return [TimerState.RUNNING, TimerState.PAUSED].includes(state.timerState)
     },
 
     // VISUALS
@@ -139,13 +139,6 @@ export const useSchedule = defineStore('schedule', {
   }
 })
 
-export const TIMERSTATE = {
-  STOPPED: 0,
-  RUNNING: 1,
-  PAUSED: 2,
-  COMPLETED: 3
-}
-
 export const ScheduleItemType = {
   WORK: 'work',
   SHORTPAUSE: 'shortpause',
@@ -155,8 +148,8 @@ export const ScheduleItemType = {
 }
 
 export const TimerState = {
-  RESET: 0,
-  TICKING: 1,
+  STOPPED: 0,
+  RUNNING: 1,
   PAUSED: 2,
   COMPLETED: 3
 }


### PR DESCRIPTION
Timers now continue ticking after they expired, showing the excess time spent on a certain timer. The traditional and approximate timers do this by showing a "+" sign in front of the timer (eg. "+01:23" or "+2 minutes").

Resetting/stopping a completed timer will first put it into the "completed" state (showing the checkmark), then resetting it to the initial value.