### PR TITLE
feat: Add app event recording

### DIFF
--- a/components/notifications/notificationController.vue
+++ b/components/notifications/notificationController.vue
@@ -35,10 +35,8 @@ export default {
       // TODO update persistent notification (if enabled)
     },
     lastEvent (newValue, oldValue) {
-      console.log(newValue)
-      if (newValue._eventType === EventType.TIMER_FINISH) {
+      if (newValue._event === EventType.TIMER_FINISH) {
         this.showNotification(this.scheduleStore.getSchedule[1].type)
-        console.log("Woohoo, timer's finished!")
       }
     }
   },

--- a/components/timer/controls/contolsBasic.vue
+++ b/components/timer/controls/contolsBasic.vue
@@ -64,6 +64,7 @@ import KeyboardListener from '@/assets/mixins/keyboardListener'
 
 import { TimerState, useSchedule } from '@/stores/schedule'
 import { useSettings } from '~/stores/settings'
+import { EventType, useEvents } from '~/stores/events'
 
 export default {
   components: {
@@ -78,7 +79,7 @@ export default {
   mixins: [KeyboardListener],
 
   computed: {
-    ...mapStores(useSettings, useSchedule),
+    ...mapStores(useSettings, useSchedule, useEvents),
 
     progressPercentage () {
       return this.scheduleStore.getCurrentItem.timeElapsed / this.scheduleStore.getCurrentItem.length
@@ -132,6 +133,7 @@ export default {
     advance () {
       this.scheduleStore.advance()
       this.scheduleStore.timerState = TimerState.STOPPED
+      this.eventsStore.recordEvent(EventType.SCHEDULE_ADVANCE_MANUAL, { next: this.scheduleStore.getSchedule[0].type })
     }
   }
 }

--- a/pages/timer.vue
+++ b/pages/timer.vue
@@ -75,7 +75,7 @@
               v-if="settingsStore.tasks.enabled"
               circle
               :importance="1"
-              class="right-5 sm:absolute transition"
+              class="transition right-5 sm:absolute"
               bg-class="dark:bg-slate-800 bg-slate-200"
               inner-class="p-5"
               :class="{'scale-0': showTodoManager}"
@@ -197,13 +197,6 @@ export default {
     },
 
     ...mapStores(useSettings, useSchedule, useEvents)
-  },
-
-  mounted () {
-    // Add visibility change listener for adaptive ticking
-    document.addEventListener('visibilitychange', () => {
-      this.settingsStore.registerNewHidden(document.hidden)
-    })
   }
 }
 </script>

--- a/stores/events.js
+++ b/stores/events.js
@@ -2,12 +2,14 @@ import { defineStore } from 'pinia'
 
 export const useEvents = defineStore('events', {
   state: () => ({
-    eventList: []
+    events: [],
+    maxEventsToKeep: 200
   }),
 
   actions: {
-    recordUserEvent (eventType) {
-      this.eventList.push(new UserEvent(new Date(), eventType))
+    recordEvent (eventType, eventData = undefined) {
+      this.events.push(new Event(eventType, { data: eventData, timestamp: new Date() }))
+      this.events.splice(0, this.events.length - this.maxEventsToKeep)
     }
   }
 })
@@ -16,21 +18,27 @@ export const state = () => ({
   eventList: []
 })
 
-export class UserEvent {
-  constructor (timestamp = new Date(), eventType = UserEventType.OTHER) {
+export class Event {
+  constructor (eventType = EventType.OTHER, { data = undefined, timestamp = new Date() }) {
     this._timestamp = timestamp
-    this._eventType = eventType
+    this._event = eventType
+
+    if (data !== undefined) {
+      this._data = data
+    }
   }
 }
 
-export const UserEventType = {
+export const EventType = {
   FOCUS_GAIN: 'focus.gain',
   FOCUS_LOST: 'focus.lost',
   TIMER_START: 'timer.start',
   TIMER_PAUSE: 'timer.pause',
   TIMER_STOP: 'timer.stop',
   TIMER_FINISH: 'timer.complete',
-  SCHEDULE_ADVANCE_MANUAL: 'schedule.advmanual',
-  SCHEDULE_ADVANCE_AUTO: 'schedule.advauto',
+  SCHEDULE_ADVANCE_MANUAL: 'schedule.adv.manual',
+  SCHEDULE_ADVANCE_AUTO: 'schedule.adv.auto',
+  APP_STARTED: 'app.start',
+  APP_ERROR: 'app.error',
   OTHER: 'other'
 }

--- a/stores/settings.js
+++ b/stores/settings.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { EventType, useEvents } from './events'
 import TickMultipliers from '@/assets/settings/adaptiveTickingMultipliers'
 import timerPresets from '@/assets/settings/timerPresets'
 
@@ -121,6 +122,7 @@ export const useSettings = defineStore('settings', {
     // mutations
     registerNewHidden (newHidden = document.hidden) {
       this.adaptiveTicking.registeredHidden = newHidden
+      useEvents().recordEvent(newHidden === true ? EventType.FOCUS_LOST : EventType.FOCUS_GAIN)
     },
 
     applyPreset (id) {


### PR DESCRIPTION
This PR enables the event store of the app to record events like the timer being started or paused. It makes it easier for different parts of the app to detect changes in the application's state and react to them and it should finish the groundwork for #245. 