### PR TITLE
feat: Add platform modules

### DIFF
--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -27,19 +27,28 @@
             />
             <Divider />
             <SettingsItem type="check" :path="['adaptiveTicking', 'enabled']" />
-            <SettingsItem type="check" :path="['timerControls', 'enableKeyboardShortcuts']" />
-            <Divider />
-            <SettingsItem type="check" :path="['permissions', 'audio']" />
-            <SettingsItem
-              type="check"
-              :path="['permissions', 'notifications']"
-              :disabled="notificationsEnabled === false"
-              @input="(newValue) => {
-                if (runtimeConfig.public.PLATFORM === 'web' && newValue === true) {
-                  eventsStore.recordEvent('permission.notification')
-                }
-              }"
-            />
+            <SettingsItem v-if="isWeb" type="check" :path="['timerControls', 'enableKeyboardShortcuts']" />
+
+            <template v-if="isWeb">
+              <Divider />
+              <SettingsItem type="check" :path="['permissions', 'audio']" />
+              <SettingsItem
+                type="check"
+                :path="['permissions', 'notifications']"
+                :disabled="notificationsEnabled === false"
+                @input="(newValue) => {
+                  if (newValue === true) {
+                    eventsStore.recordEvent('permission.notification')
+                  }
+                }"
+              />
+            </template>
+
+            <template v-if="isMobile">
+              <Divider />
+              <SettingsItem type="check" :path="['mobile', 'notifications', 'sectionOver']" />
+              <SettingsItem type="check" :path="['mobile', 'notifications', 'persistent']" />
+            </template>
 
             <Divider />
 
@@ -53,7 +62,7 @@
             />
             <SettingsItem type="check" :path="['tasks', 'removeCompletedTasks']" :disabled="!settingsStore.tasks.enabled" />
 
-            <template v-if="runtimeConfig.public.PLATFORM === 'web'">
+            <template v-if="isWeb">
               <Divider />
               <SettingsItem type="empty" :path="['manage']" />
               <div class="grid grid-flow-col grid-cols-2 gap-2 mt-1">
@@ -108,7 +117,7 @@
             />
             <Divider />
             <SettingsItem type="check" :path="['performance', 'showProgressBar']" />
-            <SettingsItem type="check" :path="['pageTitle', 'useTickEmoji']" />
+            <SettingsItem v-if="isWeb" type="check" :path="['pageTitle', 'useTickEmoji']" />
             <!-- TODO Audio volume control -->
           </div>
 
@@ -270,9 +279,12 @@ export default {
   },
 
   setup () {
+    const runtimeConfig = useRuntimeConfig()
     return {
-      runtimeConfig: useRuntimeConfig(),
-      mobileSettingsStore: useMobileSettings()
+      runtimeConfig,
+      mobileSettingsStore: useMobileSettings(),
+      isWeb: computed(() => runtimeConfig.public.PLATFORM === 'web'),
+      isMobile: computed(() => runtimeConfig.public.PLATFORM === 'mobile')
     }
   },
 

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <section v-show="processedValue" class="fixed z-40 w-full h-full p-0 md:p-4 md:max-w-screen-sm">
-    <div class="flex flex-col h-full overflow-hidden bg-white rounded-none shadow-lg md:rounded-lg dark:bg-gray-900 dark:text-gray-50">
+    <div class="flex flex-col h-full overflow-hidden bg-white rounded-none shadow-lg md:rounded-lg dark:bg-gray-900 dark:text-gray-50" :style="{ 'padding-top': `${mobileSettingsStore.padding.top}px`, 'padding-bottom': `${mobileSettingsStore.padding.bottom}px` }">
       <h1 class="px-4 mt-4 mb-2 text-xl font-bold uppercase">
         <span>{{ $t('settings.heading') }}</span>
         <Button
@@ -231,6 +231,7 @@ import presetTimers from '@/assets/settings/timerPresets'
 import { useSettings } from '~~/stores/settings'
 import { useNotifications } from '~~/stores/notifications'
 import { useMain } from '~~/stores/main'
+import { useMobileSettings } from '~~/stores/platforms/mobileSettings'
 
 import Button from '@/components/base/button.vue'
 import SettingsItem from '~~/components/settings/settingsItem.vue'
@@ -270,7 +271,8 @@ export default {
 
   setup () {
     return {
-      runtimeConfig: useRuntimeConfig()
+      runtimeConfig: useRuntimeConfig(),
+      mobileSettingsStore: useMobileSettings()
     }
   },
 

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -35,7 +35,7 @@
               :path="['permissions', 'notifications']"
               :disabled="notificationsEnabled === false"
               @input="(newValue) => {
-                if (runtimeConfig.public.platform === 'web' && newValue === true) {
+                if (runtimeConfig.public.PLATFORM === 'web' && newValue === true) {
                   eventsStore.recordEvent('permission.notification')
                 }
               }"

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -53,14 +53,14 @@
             />
             <SettingsItem type="check" :path="['tasks', 'removeCompletedTasks']" :disabled="!settingsStore.tasks.enabled" />
 
-            <Divider />
-
-            <SettingsItem type="empty" :path="['manage']" />
-            <div class="grid grid-flow-col grid-cols-2 gap-2 mt-1">
-              <ExportButton />
-              <ImportButton />
-            </div>
-
+            <template v-if="runtimeConfig.public.PLATFORM === 'web'">
+              <Divider />
+              <SettingsItem type="empty" :path="['manage']" />
+              <div class="grid grid-flow-col grid-cols-2 gap-2 mt-1">
+                <ExportButton />
+                <ImportButton />
+              </div>
+            </template>
             <Divider />
 
             <SettingsItem type="check" :path="['reset']" />

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -34,6 +34,16 @@ const iconConfig = {
   ]
 }
 
+export enum AppPlatform {
+  web = 'web',
+  mobile = 'mobile'
+}
+
+const currentPlatform = process.env.NUXT_PUBLIC_PLATFORM ?? 'web'
+console.info(`Platform is ${currentPlatform}`)
+
+// function getIgnoredFiles () { }
+
 export default defineNuxtConfig({
   /*
   ** Nuxt rendering mode
@@ -48,7 +58,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       PACKAGE_VERSION: version,
-      platform: 'web'
+      PLATFORM: AppPlatform.web
     }
   },
 
@@ -126,7 +136,12 @@ export default defineNuxtConfig({
 
   generate: {
     // Generate fallback pages (makes error pages work on Netlify, too)
-    fallback: '404.html'
+    fallback: currentPlatform === 'web' ? '404.html' : null,
+    crawler: currentPlatform === 'web',
+
+    // Exclude home and setup pages on mobile platforms
+    exclude: currentPlatform === 'mobile' ? ['/', '/setup'] : [],
+    manifest: false
   },
 
   /**

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,6 +8,7 @@ import { defineNuxtConfig } from 'nuxt'
 import VueI18nVitePlugin from '@intlify/unplugin-vue-i18n/vite'
 import VitePWAGenerator from './modules/build/pwa'
 import IconResizer from './modules/build/icon_resize'
+import { AppPlatform } from './platforms/platforms'
 
 const packageJson = fs.readFileSync('./package.json').toString()
 const version = JSON.parse(packageJson).version || 0
@@ -34,12 +35,7 @@ const iconConfig = {
   ]
 }
 
-export enum AppPlatform {
-  web = 'web',
-  mobile = 'mobile'
-}
-
-const currentPlatform = process.env.NUXT_PUBLIC_PLATFORM ?? 'web'
+const currentPlatform = process.env.NUXT_PUBLIC_PLATFORM ?? AppPlatform.web
 console.info(`Platform is ${currentPlatform}`)
 
 // function getIgnoredFiles () { }

--- a/pages/timer.vue
+++ b/pages/timer.vue
@@ -1,5 +1,12 @@
+
 <template>
-  <section class="h-full overflow-hidden transition-colors duration-300 ease-in dark:text-gray-50">
+  <section
+    class="h-full overflow-hidden transition-colors duration-300 ease-in dark:text-gray-50"
+    :style="{
+      'padding-top': `${mobileSettingsStore.padding.top}px`,
+      'padding-bottom': `${mobileSettingsStore.padding.bottom}px`
+    }"
+  >
     <Title>{{ (remainingTimeString ? `(${remainingTimeString}) ` : '') + pageTitle }}</Title>
 
     <!-- Dark mode background override -->
@@ -105,6 +112,8 @@ import TimerProgress from '@/components/timer/timerProgress.vue'
 import { AppPlatform } from '~~/platforms/platforms'
 import { useMobile } from '~~/platforms/mobile'
 
+import { useMobileSettings } from '~~/stores/platforms/mobileSettings'
+
 export default {
   name: 'PageTimer',
   components: {
@@ -131,6 +140,7 @@ export default {
 
   setup () {
     definePageMeta({ layout: 'timer', layoutTransition: false })
+    const mobileSettingsStore = useMobileSettings()
 
     const scheduleStore = useSchedule()
     const runtimeConfig = useRuntimeConfig()
@@ -168,6 +178,10 @@ export default {
       useWeb()
     } else if (runtimeConfig.public.PLATFORM === AppPlatform.mobile) {
       useMobile()
+    }
+
+    return {
+      mobileSettingsStore
     }
   },
 

--- a/pages/timer.vue
+++ b/pages/timer.vue
@@ -102,6 +102,8 @@ import TimerSwitch from '@/components/timer/display/_timerSwitch.vue'
 import TimerControls from '@/components/timer/controls/contolsBasic.vue'
 import Button from '@/components/base/button.vue'
 import TimerProgress from '@/components/timer/timerProgress.vue'
+import { AppPlatform } from '~~/platforms/platforms'
+import { useMobile } from '~~/platforms/mobile'
 
 export default {
   name: 'PageTimer',
@@ -131,6 +133,7 @@ export default {
     definePageMeta({ layout: 'timer', layoutTransition: false })
 
     const scheduleStore = useSchedule()
+    const runtimeConfig = useRuntimeConfig()
 
     const iconSvg = computed(() => `data:image/svg+xml,
       <svg
@@ -161,7 +164,11 @@ export default {
     useTicker()
 
     // TODO Load appropriate platform module based on runtime config
-    useWeb()
+    if (runtimeConfig.public.PLATFORM === AppPlatform.web) {
+      useWeb()
+    } else if (runtimeConfig.public.PLATFORM === AppPlatform.mobile) {
+      useMobile()
+    }
   },
 
   data () {

--- a/pages/timer.vue
+++ b/pages/timer.vue
@@ -2,10 +2,6 @@
 <template>
   <section
     class="h-full overflow-hidden transition-colors duration-300 ease-in dark:text-gray-50"
-    :style="{
-      'padding-top': `${mobileSettingsStore.padding.top}px`,
-      'padding-bottom': `${mobileSettingsStore.padding.bottom}px`
-    }"
   >
     <Title>{{ (remainingTimeString ? `(${remainingTimeString}) ` : '') + pageTitle }}</Title>
 
@@ -29,7 +25,13 @@
         :time-original="scheduleStore.getCurrentItem.length"
       />
     </TransitionGroup>
-    <div class="relative flex flex-col items-center justify-center w-full h-full isolate">
+    <div
+      class="relative flex flex-col items-center justify-center w-full h-full isolate"
+      :style="{
+        'padding-top': `${mobileSettingsStore.padding.top}px`,
+        'padding-bottom': `${mobileSettingsStore.padding.bottom}px`
+      }"
+    >
       <div class="flex flex-row w-full">
         <div
           class="flex flex-col overflow-hidden transition-all duration-300 bg-gray-800 shadow-lg md:w-auto"

--- a/pages/timer.vue
+++ b/pages/timer.vue
@@ -175,7 +175,7 @@ export default {
 
     useTicker()
 
-    // TODO Load appropriate platform module based on runtime config
+    // Load appropriate platform module based on runtime config
     if (runtimeConfig.public.PLATFORM === AppPlatform.web) {
       useWeb()
     } else if (runtimeConfig.public.PLATFORM === AppPlatform.mobile) {

--- a/platforms/mobile.ts
+++ b/platforms/mobile.ts
@@ -1,4 +1,5 @@
 import { useMobileSettings } from '~~/stores/platforms/mobileSettings'
+import { useEvents, EventType } from '~~/stores/events'
 
 interface FlutterJavascriptChannel {
   postMessage(message: string): void;
@@ -6,7 +7,8 @@ interface FlutterJavascriptChannel {
 
 enum FlutterMessageType {
   clientReady = 'ready',
-  setPadding = 'setPadding'
+  setPadding = 'setPadding',
+  showNotification = 'showNotification'
 }
 
 interface FlutterMessage {
@@ -22,6 +24,7 @@ declare global {
 
 export function useMobile () {
   const mobileSettingsStore = useMobileSettings()
+  const eventsStore = useEvents()
 
   onMounted(() => {
     console.info('Mobile platform loaded')
@@ -48,6 +51,19 @@ export function useMobile () {
           break
       }
     }
+
+    // register store watcher
+    eventsStore.$subscribe(() => {
+      if (eventsStore.lastEvent._event === EventType.TIMER_FINISH) {
+        window.NativeFramework.postMessage(JSON.stringify({
+          type: FlutterMessageType.showNotification,
+          payload: {
+            title: 'Hello',
+            description: 'This is a test notification :)'
+          }
+        } as FlutterMessage))
+      }
+    })
 
     window.NativeFramework.postMessage(JSON.stringify({ type: FlutterMessageType.clientReady } as FlutterMessage))
   })

--- a/platforms/mobile.ts
+++ b/platforms/mobile.ts
@@ -5,6 +5,7 @@ interface FlutterJavascriptChannel {
 }
 
 enum FlutterMessageType {
+  clientReady = 'ready',
   setPadding = 'setPadding'
 }
 
@@ -22,25 +23,32 @@ declare global {
 export function useMobile () {
   const mobileSettingsStore = useMobileSettings()
 
-  console.info('Mobile platform loaded')
+  onMounted(() => {
+    console.info('Mobile platform loaded')
 
-  if (!window.NativeFramework) {
-    console.warn('Native framework not found')
-    return
-  }
-
-  window.Send = function (msg: FlutterMessage) {
-    console.log(`Got: ${JSON.stringify(msg)}`)
-
-    switch (msg.type) {
-      case FlutterMessageType.setPadding:
-        mobileSettingsStore.$patch({
-          padding: msg.payload
-        })
-
-        break
+    if (!window) {
+      console.warn('Window does not exist, quitting')
+      return
     }
-  }
 
-  window.NativeFramework.postMessage('Hola')
+    if (!window.NativeFramework) {
+      console.warn('Native framework not found')
+      return
+    }
+
+    window.Send = function (msg: FlutterMessage) {
+      console.log(`Got: ${JSON.stringify(msg)}`)
+
+      switch (msg.type) {
+        case FlutterMessageType.setPadding:
+          mobileSettingsStore.$patch({
+            padding: msg.payload
+          })
+
+          break
+      }
+    }
+
+    window.NativeFramework.postMessage(JSON.stringify({ type: FlutterMessageType.clientReady } as FlutterMessage))
+  })
 }

--- a/platforms/mobile.ts
+++ b/platforms/mobile.ts
@@ -23,6 +23,7 @@ interface FlutterMessage {
 declare global {
   interface Window {
     NativeFramework?: FlutterJavascriptChannel
+    Send?: (msg: FlutterMessage) => void
   }
 }
 

--- a/platforms/mobile.ts
+++ b/platforms/mobile.ts
@@ -1,0 +1,21 @@
+interface FlutterJavascriptChannel {
+  postMessage(message: string): void;
+}
+
+declare global {
+  interface Window {
+    NativeFramework?: FlutterJavascriptChannel
+  }
+}
+
+export function useMobile () {
+  console.info('Mobile platform loaded')
+
+  if (!window.NativeFramework) {
+    console.warn('Native framework not found')
+    return
+  }
+
+  console.log(window.NativeFramework)
+  window.NativeFramework.postMessage('Hola')
+}

--- a/platforms/mobile.ts
+++ b/platforms/mobile.ts
@@ -1,5 +1,16 @@
+import { useMobileSettings } from '~~/stores/platforms/mobileSettings'
+
 interface FlutterJavascriptChannel {
   postMessage(message: string): void;
+}
+
+enum FlutterMessageType {
+  setPadding = 'setPadding'
+}
+
+interface FlutterMessage {
+  type: FlutterMessageType,
+  payload: unknown
 }
 
 declare global {
@@ -9,6 +20,8 @@ declare global {
 }
 
 export function useMobile () {
+  const mobileSettingsStore = useMobileSettings()
+
   console.info('Mobile platform loaded')
 
   if (!window.NativeFramework) {
@@ -16,6 +29,18 @@ export function useMobile () {
     return
   }
 
-  console.log(window.NativeFramework)
+  window.Send = function (msg: FlutterMessage) {
+    console.log(`Got: ${JSON.stringify(msg)}`)
+
+    switch (msg.type) {
+      case FlutterMessageType.setPadding:
+        mobileSettingsStore.$patch({
+          padding: msg.payload
+        })
+
+        break
+    }
+  }
+
   window.NativeFramework.postMessage('Hola')
 }

--- a/platforms/mobile.ts
+++ b/platforms/mobile.ts
@@ -8,7 +8,8 @@ interface FlutterJavascriptChannel {
 enum FlutterMessageType {
   clientReady = 'ready',
   setPadding = 'setPadding',
-  showNotification = 'showNotification'
+  showNotification = 'showNotification',
+  appEvent = 'appEvent'
 }
 
 interface FlutterMessage {
@@ -54,6 +55,11 @@ export function useMobile () {
 
     // register store watcher
     eventsStore.$subscribe(() => {
+      window.NativeFramework.postMessage(JSON.stringify({
+        type: FlutterMessageType.appEvent,
+        payload: eventsStore.lastEvent
+      } as FlutterMessage))
+
       if (eventsStore.lastEvent._event === EventType.TIMER_FINISH) {
         window.NativeFramework.postMessage(JSON.stringify({
           type: FlutterMessageType.showNotification,

--- a/platforms/platforms.ts
+++ b/platforms/platforms.ts
@@ -1,0 +1,4 @@
+export enum AppPlatform {
+  web = 'web',
+  mobile = 'mobile'
+}

--- a/stores/platforms/mobileSettings.ts
+++ b/stores/platforms/mobileSettings.ts
@@ -1,0 +1,10 @@
+import { defineStore } from 'pinia'
+
+export const useMobileSettings = defineStore('platforms:mobile', {
+  state: () => ({
+    padding: {
+      top: 0,
+      bottom: 0
+    }
+  })
+})

--- a/stores/schedule.ts
+++ b/stores/schedule.ts
@@ -1,6 +1,19 @@
 import { defineStore } from 'pinia'
 import { ColorMethod, useSettings } from './settings'
 
+export enum ETimerState {
+  STOPPED,
+  RUNNING,
+  PAUSED,
+  COMPLETED
+}
+export interface ScheduleEntry {
+  id: number,
+  timeElapsed: number,
+  length?: number,
+  type?: ETimerState
+}
+
 export const useSchedule = defineStore('schedule', {
   state: () => ({
     items: createScheduleSeries(10),
@@ -30,7 +43,7 @@ export const useSchedule = defineStore('schedule', {
     },
 
     /** Getter to retrieve schedule with all necessary information filled in */
-    getSchedule (state) {
+    getSchedule (state): ScheduleEntry[] {
       const settings = useSettings()
       const scheduleSettings = settings.schedule
       const numEntities = scheduleSettings.numScheduleEntries
@@ -70,7 +83,7 @@ export const useSchedule = defineStore('schedule', {
       return returnArray
     },
 
-    getCurrentItem () {
+    getCurrentItem (): ScheduleEntry {
       return this.getSchedule[0]
     },
 
@@ -159,7 +172,7 @@ export const TimerState = {
   COMPLETED: 3
 }
 
-function createScheduleEntry (id) {
+function createScheduleEntry (id): ScheduleEntry {
   return {
     id,
     timeElapsed: 0,
@@ -169,7 +182,7 @@ function createScheduleEntry (id) {
 }
 
 function createScheduleSeries (numEntries) {
-  const items = []
+  const items = [] as ScheduleEntry[]
   for (let i = 0; i < numEntries; i++) {
     items.push(createScheduleEntry(i))
   }

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -98,6 +98,12 @@ export const useSettings = defineStore('settings', {
     pageTitle: {
       useTickEmoji: true
     },
+    mobile: {
+      notifications: {
+        sectionOver: true,
+        persistent: false
+      }
+    },
     reset: false
   }),
 


### PR DESCRIPTION
This PR adds a basic version of the mobile platform module and logic for handling which platform module to load on the timer page. The platform is `web` by default but can be changed to mobile by specifying the `NUXT_PUBLIC_PLATFORM=mobile` environment variable when running `yarn dev` or `yarn generate[:modern]`.

The `mobile` platform module is used to communicate with the Flutter app (that is early in the making), while the `web` module works in PWA mode. The `mobile` module will be updated in the future as the mobile app is developed. 