### PR TITLE
chore(i18n): Fix translations after upgrade

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -234,6 +234,18 @@
         "_title": "Manage settings",
         "_description": "Download the current settings or load them from a file"
       },
+      "mobile": {
+        "notifications": {
+          "sectionOver": {
+            "_title": "Section over notifications",
+            "_description": "Show a notification when a section is over"
+          },
+          "persistent": {
+            "_title": "Persistent notification",
+            "_description": "Display the progress of the current timer"
+          }
+        }
+      },
       "lang": {
         "_title": "Language",
         "_description": ""

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -218,8 +218,7 @@
       "cancel": "Annuler"
     },
     "manage": {
-      "heading": "Gérer les paramètres",
-      "description": "Télécharger les paramètres actuels ou les charger à partir d'un fichier",
+
       "buttons": {
         "save": "Sauvegarder",
         "load": "Charger"
@@ -233,6 +232,10 @@
       "share": "ou partagez l'application sur les réseaux sociaux :"
     },
     "values": {
+      "manage": {
+        "_title": "Gérer les paramètres",
+        "_description": "Télécharger les paramètres actuels ou les charger à partir d'un fichier"
+      },
       "lang": {
         "_description": "",
         "_title": "Langue"

--- a/i18n/hr.json
+++ b/i18n/hr.json
@@ -218,8 +218,6 @@
       "cancel": "Odustani"
     },
     "manage": {
-      "heading": "Upravljaj postavkama",
-      "description": "Preuzmi trenutačne postavke ili učitaj postavke iz datoteke",
       "buttons": {
         "save": "Spremi",
         "load": "Učitaj"
@@ -233,6 +231,10 @@
       "share": "ili dijeli program na društvenim mrežama:"
     },
     "values": {
+      "manage": {
+        "_title": "Upravljaj postavkama",
+        "_description": "Preuzmi trenutačne postavke ili učitaj postavke iz datoteke"
+      },
       "lang": {
         "_title": "Jezik",
         "_description": ""

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -218,8 +218,7 @@
       "cancel": "Mégsem"
     },
     "manage": {
-      "heading": "Beállítások kezelése",
-      "description": "A jelenlegi beállításokat letöltheted egy fájlba vagy vissza is állíthatod onnan",
+      
       "buttons": {
         "save": "Mentés",
         "load": "Betöltés"
@@ -233,6 +232,10 @@
       "share": "vagy oszd meg ismerőseiddel az alkalmazást:"
     },
     "values": {
+      "manage": {
+        "_title": "Beállítások kezelése",
+        "_description": "A jelenlegi beállításokat letöltheted egy fájlba vagy vissza is állíthatod onnan"
+      },
       "lang": {
         "_title": "Nyelv",
         "_description": ""


### PR DESCRIPTION
This PR fixes the broken "manage" settings translations in non-English languages and adds missing strings for some mobile-only settings.