### PR TITLE
fix: Fix hydration issues

### DIFF
--- a/components/timer/display/_timerSwitch.vue
+++ b/components/timer/display/_timerSwitch.vue
@@ -15,12 +15,17 @@ import { AvailableTimers } from '~~/stores/settings'
 import TimerMixin from '@/assets/mixins/timerMixin'
 import { useSchedule, TimerState } from '~~/stores/schedule'
 
+import TimerTraditional from '@/components/timer/display/timerTraditional.vue'
+import TimerApproximate from '@/components/timer/display/timerApproximate.vue'
+import TimerPercentage from '@/components/timer/display/timerPercentage.vue'
+import CompleteMarker from '@/components/timer/display/timerComplete.vue'
+
 export default {
   components: {
-    TimerTraditional: defineAsyncComponent(() => import('@/components/timer/display/timerTraditional.vue')),
-    TimerApproximate: defineAsyncComponent(() => import('@/components/timer/display/timerApproximate.vue')),
-    TimerPercentage: defineAsyncComponent(() => import('@/components/timer/display/timerPercentage.vue')),
-    CompleteMarker: defineAsyncComponent(() => import('@/components/timer/display/timerComplete.vue'))
+    TimerTraditional,
+    TimerApproximate,
+    TimerPercentage,
+    CompleteMarker
   },
   mixins: [TimerMixin],
   props: {

--- a/plugins/store-persist.client.ts
+++ b/plugins/store-persist.client.ts
@@ -54,7 +54,9 @@ function restoreStore (store) {
   const stateToRestore = JSON.parse(localStorage.getItem(getStorePersistenceKey(store.$id)))
 
   if (stateToRestore !== null) {
-    store.$patch(stateToRestore)
+    onMounted(() => {
+      store.$patch(stateToRestore)
+    })
 
     console.log(`Restoring ${store.$id}`)
     const mainStore = useMain()


### PR DESCRIPTION
This PR fixes hydration issues after reloading the page. This error was potentially caused by too early store state patches. For now, this might cause a "jump" in the application when state is suddenly restored - in the future a splash screen might be reintroduced to hide this.

PS: The root cause of the hydration error is yet unknown, but it seemed to work before the dependency updates.