### PR TITLE
fix(serviceworker): Fix service worker not registering

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -22,9 +22,16 @@ if (!process.server) {
   onMounted(() => {
     if (typeof window !== 'undefined') {
       if ('serviceWorker' in navigator) {
-        window.addEventListener('load', function () {
+        const registerSw = () => {
+          console.debug(`Registering service worker at /${swPath}`)
           navigator.serviceWorker.register(`/${swPath}`)
-        })
+        }
+
+        if (document.readyState === 'complete') {
+          registerSw()
+        } else {
+          window.addEventListener('load', registerSw)
+        }
       }
     }
   })


### PR DESCRIPTION
Sometimes the service worker registration code (that used the `load` window event) was registered *after* the document was loaded, causing the service worker not to register. This PR makes the registration code more robust by first checking `document.readyState`.