### PR TITLE
refactor: Change display strings to FocusTide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# AnotherPomodoro contribution guidelines
+# FocusTide contribution guidelines
 
-**AnotherPomodoro** is not a huge project and as such its guidelines are not so strict, either. It might be a great project for beginners and students to implement new features or bug fixes in.
+**FocusTide** is not a huge project and as such its guidelines are not so strict, either. It might be a great project for beginners and students to implement new features or bug fixes in.
 
 Still, **before contributing, please read this short guide** to make sure you submit a new issue or pull request the right way!
 
@@ -82,7 +82,7 @@ If that feature request is approved or there is a concrete idea to implement:
 
 ## Submitting pull requests
 
-AnotherPomodoro is an open software and such it welcomes others to contribute code (fixes or features) to it. Adhering to the following simple rules will help your code get accepted:
+FocusTide is an open software and such it welcomes others to contribute code (fixes or features) to it. Adhering to the following simple rules will help your code get accepted:
 
 * Before submitting code, please start a discussion (either [on the discussions](https://github.com/Hanziness/AnotherPomodoro/discussions) or the [issues page](https://github.com/Hanziness/AnotherPomodoro/issues)). **Code submitted without prior discussion will likely not be accepted.**
 * Fork the repository. **Don't forget to switch to the `develop` branch after cloning!**

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ⏳ AnotherPomodoro
+# ⏳ FocusTide
 
 Free and open-source Pomodoro application, right in your browser.
 
-[<img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" height="54">](https://www.buymeacoffee.com/imreg?utm_source=github&utm_medium=web&utm_content=readme) <a href="https://www.producthunt.com/posts/anotherpomodoro?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-anotherpomodoro" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=327185&theme=light" alt="AnotherPomodoro - Modern & customizable productivity timer | Product Hunt" width="250" height="54" /></a>
+[<img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" height="54">](https://www.buymeacoffee.com/imreg?utm_source=github&utm_medium=web&utm_content=readme) <a href="https://www.producthunt.com/posts/anotherpomodoro?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-anotherpomodoro" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=327185&theme=light" alt="FocusTide - Modern & customizable productivity timer | Product Hunt" width="250" height="54" /></a>
 
 ![Netlify Status](https://api.netlify.com/api/v1/badges/7cb2b7fb-cacd-4acf-803b-8af9dad9f2a8/deploy-status) ![License](https://img.shields.io/github/license/Hanziness/AnotherPomodoro) ![GitHub package.json version](https://img.shields.io/github/package-json/v/Hanziness/AnotherPomodoro) [![Crowdin translation status](https://badges.crowdin.net/anotherpomodoro/localized.svg)](https://crowdin.com/project/anotherpomodoro)
 
@@ -10,11 +10,11 @@ Free and open-source Pomodoro application, right in your browser.
 
 ## What is it?
 
-AnotherPomodoro is a Pomodoro timer application running in the browser. It helps you manage your time so that you can do more work instead of watching videos of cute cats 😿
+FocusTide is a Pomodoro timer application running in the browser. It helps you manage your time so that you can do more work instead of watching videos of cute cats 😿
 
 ### Quickstart: your schedule
 
-When working with AnotherPomodoro, you'll be moving between three types of sessions:
+When working with FocusTide, you'll be moving between three types of sessions:
 
 1. **Work**. <br> Do what you have to do.
 2. (Short) **Pause**. <br> Take a short rest, stand up from your computer and drink some water.

--- a/components/settings/aboutTab.vue
+++ b/components/settings/aboutTab.vue
@@ -14,7 +14,7 @@ const mainStore = useMain()
     <img src="/favicon.svg" width="64" height="64" class="inline-block p-2 mb-1 bg-red-200 rounded-lg">
     <div>
       <div class="inline-block text-2xl font-bold">
-        AnotherPomodoro
+        FocusTide
       </div>
       <sup class="text-base" v-text="mainStore.version" />
     </div>

--- a/components/settings/exportButton.vue
+++ b/components/settings/exportButton.vue
@@ -25,7 +25,7 @@ export default {
 
       const downloadElement = document.createElement('a')
       downloadElement.href = `data:text/plain;charset=utf-8,${encodeURIComponent(JSON.stringify(downloadObject))}`
-      downloadElement.download = 'anotherpomodoro-settings.json'
+      downloadElement.download = 'focustide-settings.json'
       downloadElement.style.display = 'none'
       document.body.appendChild(downloadElement)
       downloadElement.click()

--- a/components/socialButtons/supportButton.vue
+++ b/components/socialButtons/supportButton.vue
@@ -35,7 +35,7 @@ export default {
     },
     utmTags: {
       type: String,
-      default: '?utm_source=AnotherPomodoro&utm_medium=web&utm_content=settings'
+      default: '?utm_source=FocusTide&utm_medium=web&utm_content=settings'
     },
     iconSize: {
       type: String,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3,7 +3,7 @@
     "app_description": "Free Pomodoro timer right in your browser",
     "alt": {
       "img": {
-        "screenshot": "Screenshot of a timer running in AnotherPomodoro",
+        "screenshot": "Screenshot of a timer running in FocusTide",
         "icon": "The app's icon"
       },
       "links": {
@@ -112,7 +112,7 @@
     "support": {
       "title": "Support this project",
       "subtitle": {
-        "main": "AnotherPomodoro is being developed as a side project with no compensation in mind.",
+        "main": "FocusTide is being developed as a side project with no compensation in mind.",
         "action": "If you feel that this is a project worth supporting, please do so."
       },
       "credits": "Made with ❤ by Imre Gera"
@@ -136,7 +136,7 @@
       },
       "timerstyle": {
         "title": "Timer display",
-        "description": "AnotherPomodoro supports three timer styles ranging from seconds-precision to showing only a percentage."
+        "description": "FocusTide supports three timer styles ranging from seconds-precision to showing only a percentage."
       },
       "permissions": {
         "title": "Permissions",
@@ -225,7 +225,7 @@
       "madeby": "Made by Imre Gera",
       "source": "Source code",
       "support": "Support the project",
-      "supportBody": "I develop AnotherPomodoro in my free time. It would mean a lot to me if you could help me keep working on it!",
+      "supportBody": "I develop FocusTide in my free time. It would mean a lot to me if you could help me keep working on it!",
       "mobileSupport": "Due to the rules enforced by the Google Play Store, I cannot show you any links inside the mobile app to donate to the project.",
       "share": "or share the app on social media:"
     },
@@ -467,7 +467,7 @@
     "onboarding": {
       "pages": {
         "0": {
-          "title": "Welcome to AnotherPomodoro!",
+          "title": "Welcome to FocusTide!",
           "text": "Take a quick look around on how to use the app effectively."
         },
         "1": {

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -3,7 +3,7 @@
     "app_description": "Temporizador Pomodoro gratuito directamente en su navegador",
     "alt": {
       "img": {
-        "screenshot": "Captura de pantalla de un temporizador en funcionamiento en AnotherPomodoro",
+        "screenshot": "Captura de pantalla de un temporizador en funcionamiento en FocusTide",
         "icon": "El icono de la aplicación"
       },
       "links": {
@@ -112,7 +112,7 @@
     "support": {
       "title": "Apoye este proyecto",
       "subtitle": {
-        "main": "AnotherPomodoro está siendo desarrollado como un proyecto paralelo sin ninguna compensación en mente.",
+        "main": "FocusTide está siendo desarrollado como un proyecto paralelo sin ninguna compensación en mente.",
         "action": "Si siente que este es un proyecto que vale la pena apoyar, por favor hágalo."
       },
       "credits": "Hecho con ❤ por Imre Gera"
@@ -136,7 +136,7 @@
       },
       "timerstyle": {
         "title": "Vista del temporizador",
-        "description": "AnotherPomodoro soporta tres estilos de temporizador que van desde preciso a los segundos hasta mostrar solo un porcentaje."
+        "description": "FocusTide soporta tres estilos de temporizador que van desde preciso a los segundos hasta mostrar solo un porcentaje."
       },
       "permissions": {
         "title": "Permisos",
@@ -225,7 +225,7 @@
       "madeby": "Hecho por Imre Gera",
       "source": "Código fuente",
       "support": "Apoye el proyecto",
-      "supportBody": "Desarrollo AnotherPomodoro en mi tiempo libre. ¡Significaría mucho para mí si pudiera ayudarme a seguir trabajando en él!",
+      "supportBody": "Desarrollo FocusTide en mi tiempo libre. ¡Significaría mucho para mí si pudiera ayudarme a seguir trabajando en él!",
       "mobileSupport": "Debido a las reglas impuestas por la Google Play Store, no puedo mostrarle ningún enlace dentro de la aplicación móvil para donar al proyecto.",
       "share": "o comparta la aplicación en redes sociales:"
     },
@@ -467,7 +467,7 @@
     "onboarding": {
       "pages": {
         "0": {
-          "title": "¡Bienvenido/a AnotherPomodoro!",
+          "title": "¡Bienvenido/a FocusTide!",
           "text": "Eche un vistazo a cómo utilizar la aplicación de forma eficaz."
         },
         "1": {

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -3,7 +3,7 @@
     "app_description": "Minuteur Pomodoro gratuit directement dans votre navigateur",
     "alt": {
       "img": {
-        "screenshot": "Capture d'écran du minuteur de AnotherPomodoro",
+        "screenshot": "Capture d'écran du minuteur de FocusTide",
         "icon": "L'icone de l'app"
       },
       "links": {
@@ -80,7 +80,7 @@
     "support": {
       "title": "Soutenez ce projet",
       "subtitle": {
-        "0": "AnotherPomodoro est développé en tant que projet personnel, sans .",
+        "0": "FocusTide est développé en tant que projet personnel, sans .",
         "1": {
           "base": "Si vous pensez que ce projet mérite d'être soutenu, {0}.",
           "action": "soutenez-le"
@@ -143,7 +143,7 @@
         "title": "Durée de la minuterie"
       },
       "timerstyle": {
-        "description": "AnotherPomodoro prend en charge trois styles de minuterie allant de la précision à la seconde à l'affichage d'un pourcentage seulement.",
+        "description": "FocusTide prend en charge trois styles de minuterie allant de la précision à la seconde à l'affichage d'un pourcentage seulement.",
         "title": "Affichage de la minuterie"
       },
       "tip": {
@@ -458,7 +458,7 @@
       "pages": {
         "0": {
           "text": "Jetez un coup d'œil sur la façon d'utiliser l'application efficacement.",
-          "title": "Bienvenue sur AnotherPomodoro !"
+          "title": "Bienvenue sur FocusTide !"
         },
         "1": {
           "text": "Travaillez ou faites une pause jusqu'à la fin du temps imparti. \nEnsuite, passez au prochain minuteur.",

--- a/i18n/hr.json
+++ b/i18n/hr.json
@@ -3,7 +3,7 @@
     "app_description": "Besplatni Pomodoro izravno u tvom pregledniku",
     "alt": {
       "img": {
-        "screenshot": "Slika pokrenutog timera u programu AnotherPomodoro",
+        "screenshot": "Slika pokrenutog timera u programu FocusTide",
         "icon": "Ikona programa"
       },
       "links": {
@@ -112,7 +112,7 @@
     "support": {
       "title": "Podrži ovaj projekt",
       "subtitle": {
-        "main": "AnotherPomodoro se razvija kao sporedni projekt bez naknade.",
+        "main": "FocusTide se razvija kao sporedni projekt bez naknade.",
         "action": "Ako smatraš da je ovaj projekt vrijedan podrške, podrži ga."
       },
       "credits": "Izrađen sa ❤. Autor: Imre Gera"
@@ -136,7 +136,7 @@
       },
       "timerstyle": {
         "title": "Prikaz timera",
-        "description": "AnotherPomodoro podržava tri stila timera, od točnosti u sekundama do prikaza postotka."
+        "description": "FocusTide podržava tri stila timera, od točnosti u sekundama do prikaza postotka."
       },
       "permissions": {
         "title": "Dozvole",
@@ -225,7 +225,7 @@
       "madeby": "Autor: Imre Gera",
       "source": "Izvorni kod",
       "support": "Podrži projekt",
-      "supportBody": "AnotherPomodoro razvijam u slobodno vrijeme. Puno bi mi značilo kad bi mi pomogao/la nastaviti rad na programu!",
+      "supportBody": "FocusTide razvijam u slobodno vrijeme. Puno bi mi značilo kad bi mi pomogao/la nastaviti rad na programu!",
       "mobileSupport": "Zbog pravila koja provodi Google Play Store, ne mogu pokazati poveznice unutar mobilnog programa za doniranje projektu.",
       "share": "ili dijeli program na društvenim mrežama:"
     },
@@ -467,7 +467,7 @@
     "onboarding": {
       "pages": {
         "0": {
-          "title": "Dobro došao, dobro došla u AnotherPomodoro!",
+          "title": "Dobro došao, dobro došla u FocusTide!",
           "text": "Pogledaj kako učinkovito koristiti program."
         },
         "1": {

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -3,7 +3,7 @@
     "app_description": "Ingyenes Pomodoro alkalmazás közvetlenül a böngésződben",
     "alt": {
       "img": {
-        "screenshot": "Képernyőkép egy futó időzítőről az AnotherPomodoro alkalmazásban",
+        "screenshot": "Képernyőkép egy futó időzítőről az FocusTide alkalmazásban",
         "icon": "Az alkalmazás ikonja"
       },
       "links": {
@@ -112,7 +112,7 @@
     "support": {
       "title": "Támogasd a projektet",
       "subtitle": {
-        "main": "Az AnotherPomodoro hobbiprojektként készült, bárminemű anyagi bevétel szándéka nélkül.",
+        "main": "Az FocusTide hobbiprojektként készült, bárminemű anyagi bevétel szándéka nélkül.",
         "action": "Ha úgy érzed, ennek ellenére megérdemli, kérlek támogasd a projektet."
       },
       "credits": "❤ Szeretettel készítette: Gera Imre"
@@ -136,7 +136,7 @@
       },
       "timerstyle": {
         "title": "Időzítő stílusa",
-        "description": "Az AnotherPomodoro háromféle időzítő megjelenést is támogat a másodperc pontosságútól a százalékos megjelenítésig."
+        "description": "Az FocusTide háromféle időzítő megjelenést is támogat a másodperc pontosságútól a százalékos megjelenítésig."
       },
       "permissions": {
         "title": "Engedélyek",
@@ -225,7 +225,7 @@
       "madeby": "Készítette: Gera Imre",
       "source": "Forráskód",
       "support": "Támogasd a projektet",
-      "supportBody": "Az AnotherPomodorot a szabadidőmben fejlesztem, sokat jelentene, ha segítenél továbbfejleszteni!",
+      "supportBody": "Az FocusTidet a szabadidőmben fejlesztem, sokat jelentene, ha segítenél továbbfejleszteni!",
       "mobileSupport": "A Google Play áruház szabályai miatt nem jeleníthetek meg semmilyen hivatkozást az anyagi támogatáshoz.",
       "share": "vagy oszd meg ismerőseiddel az alkalmazást:"
     },
@@ -467,7 +467,7 @@
     "onboarding": {
       "pages": {
         "0": {
-          "title": "Üdvözöl az AnotherPomodoro!",
+          "title": "Üdvözöl az FocusTide!",
           "text": "Tekints meg egy gyorstalpalót az alkalmazás hatékony használatáról."
         },
         "1": {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -189,7 +189,7 @@ export default defineNuxtConfig({
   */
   googleFonts: {
     families: {
-      Poppins: [400, 700]
+      Lexend: [400, 700]
     },
     display: 'swap'
     // download: true

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -68,13 +68,13 @@ export default defineNuxtConfig({
   */
   head: {
     titleTemplate: '%s',
-    title: 'AnotherPomodoro',
+    title: 'FocusTide',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no' },
       { hid: 'description', name: 'description', content: process.env.npm_package_description || '' },
       { hid: 'keywords', name: 'keywords', content: 'pomodoro app, pomodoro, free, productivity tool, app, open-source, online timer, countdown timer, focus timer, pomodoro clock, no ads, productivity timer, todo list, task management, tomato timer, pwa' },
-      { hid: 'twitter:title', name: 'twitter:title', content: 'AnotherPomodoro' },
+      { hid: 'twitter:title', name: 'twitter:title', content: 'FocusTide' },
       { hid: 'twitter:description', name: 'twitter:description', content: process.env.npm_package_description || '' },
       { hid: 'twitter:image', name: 'twitter:image', content: '/img/ogImage.png' },
       { hid: 'og:image', property: 'og:image', content: '/img/ogImage.png' },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -27,7 +27,7 @@
               <!-- App name and slogan -->
               <div class="flex flex-col">
                 <h1 class="text-3xl font-bold md:text-5xl">
-                  AnotherPomodoro
+                  FocusTide
                 </h1>
                 <div class="text-lg md:text-xl" v-text="$t('index.app_description')" />
               </div>
@@ -97,7 +97,7 @@
       <div class="flex flex-col items-center text-sky-900">
         <h2 class="text-5xl font-bold tracking-tight uppercase" v-text="$t('index.section_whatitdoes.title')" />
         <div class="mt-2 text-lg text-center xl:text-xl">
-          <p v-text="$t('index.section_whatitdoes.subtitle.main', { appname: 'AnotherPomodoro' })" />
+          <p v-text="$t('index.section_whatitdoes.subtitle.main', { appname: 'FocusTide' })" />
           <p v-text="$t('index.section_whatitdoes.subtitle.sub')" />
         </div>
 
@@ -237,7 +237,7 @@ export default {
 
   head () {
     return {
-      title: 'AnotherPomodoro',
+      title: 'FocusTide',
       link: [
         { rel: 'icon', href: '/favicon.svg' }
       ]

--- a/pages/timer.vue
+++ b/pages/timer.vue
@@ -160,7 +160,7 @@ export default {
       meta: [{
         hid: 'description',
         name: 'description',
-        content: 'Jumpstart your productivity sessions with AnotherPomodoro. Start your timer session on this page, or check the home page for a guided tour!'
+        content: 'Jumpstart your productivity sessions with FocusTide. Start your timer session on this page, or check the home page for a guided tour!'
       }],
       link: [
         {

--- a/platforms/web.ts
+++ b/platforms/web.ts
@@ -152,7 +152,7 @@ export function useWeb () {
 
     try {
       new Notification(i18n.t('notification.' + nextState + '.title'), {
-        tag: 'AnotherPomodoro-SectionNotify',
+        tag: 'FocusTide-SectionNotify',
         body: i18n.t('notification.' + nextState + '.body'),
         actions: notificationActions
       })

--- a/public/app_manifest.json
+++ b/public/app_manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/web-manifest-combined.json",
-  "name": "AnotherPomodoro: modern & simple Pomodoro app",
-  "short_name": "AnotherPomodoro",
+  "name": "FocusTide: modern & simple Pomodoro app",
+  "short_name": "FocusTide",
   "description": "Modern and customisable productivity timer, right in your browser!",
   "start_url": "/timer?pwa=true",
   "theme_color": "#F87171",
@@ -38,7 +38,7 @@
       "sizes": "1520x3040",
       "type": "image/jpg",
       "platform": "narrow",
-      "label": "Every feature is optional in AnotherPomodoro. If all you need is a simple timer, it can do that, too."
+      "label": "Every feature is optional in FocusTide. If all you need is a simple timer, it can do that, too."
     },
     {
       "src": "/assets/img/screenshots/stores/mobile_4.jpg",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,9 +11,9 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        display: ['Poppins', 'sans-serif'],
-        body: ['Poppins', 'sans-serif'],
-        sans: ['Poppins', 'sans-serif']
+        display: ['Lexend', 'sans-serif'],
+        body: ['Lexend', 'sans-serif'],
+        sans: ['Lexend', 'sans-serif']
       },
       colors: {
         primary: colors.red[400],


### PR DESCRIPTION
As part of an effort to rebrand the app from AnotherPomodoro to FocusTide (to remove references to the word "Pomodoro"), (hopefully all) display strings, including those in the translations, were replaced. Links will be updated in the future. The app now uses Lexend (Deca) as its main display font.