### PR TITLE
fix(appbar): Fix button paddings

### DIFF
--- a/components/appBar.vue
+++ b/components/appBar.vue
@@ -28,6 +28,7 @@ const settingsStore = useSettings()
       :importance="ButtonImportance.Filled"
       class="transition rounded-full h-11"
       no-content-theme
+      no-padding
       inner-class="p-1"
       @click="openPanels.todo = !openPanels.todo"
     >
@@ -39,6 +40,7 @@ const settingsStore = useSettings()
       :theme="ButtonTheme.Neutral"
       class="h-11"
       no-content-theme
+      no-padding
       inner-class="p-1"
       @click="openPanels.settings = !openPanels.settings"
     >


### PR DESCRIPTION
This PR disables the base padding on the buttons of the app bar, making the icons align to the centre again.