### PR TITLE
refactor!: Change most URLs to FocusTide

### DIFF
--- a/components/settings/aboutTab.vue
+++ b/components/settings/aboutTab.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { CoffeeIcon, BrandGithubIcon, BrandTwitterIcon, BrandFacebookIcon, BrandRedditIcon } from 'vue-tabler-icons'
+import { ButtonImportance } from '../base/types/button'
 import Button from '~~/components/base/uiButton.vue'
 import { AppPlatform } from '~~/platforms/platforms'
 import { useMain } from '~~/stores/main'
-import { ButtonImportance } from '../base/types/button';
 
 const runtimeConfig = useRuntimeConfig()
 const isMobile = computed(() => runtimeConfig.public.PLATFORM === AppPlatform.mobile)

--- a/components/settings/aboutTab.vue
+++ b/components/settings/aboutTab.vue
@@ -35,7 +35,7 @@ const mainStore = useMain()
           link
           no-default-style
           no-content-theme
-          href="https://www.github.com/Hanziness/AnotherPomodoro?utm_source=AnotherPomodoro&utm_medium=web&utm_content=settings"
+          href="https://www.github.com/Hanziness/AnotherPomodoro?utm_source=FocusTide&utm_medium=web&utm_content=settings"
           inner-class="flex flex-row items-center gap-1 text-slate-50 text-gray-50"
           bg-class="bg-slate-900 dark:bg-slate-700"
         >
@@ -49,7 +49,7 @@ const mainStore = useMain()
           dark
           no-default-style
           no-content-theme
-          href="https://www.buymeacoffee.com/imreg?utm_source=AnotherPomodoro&utm_medium=web&utm_content=settings"
+          href="https://www.buymeacoffee.com/imreg?utm_source=FocusTide&utm_medium=web&utm_content=settings"
           inner-class="flex flex-row items-center gap-1 text-black"
           bg-class="bg-yellow-300"
         >
@@ -77,7 +77,7 @@ const mainStore = useMain()
           no-default-style
           no-content-theme
           :importance="ButtonImportance.Filled"
-          href="https://twitter.com/AnotherPomodoro?utm_source=AnotherPomodoro&utm_medium=web&utm_content=settings"
+          href="https://twitter.com/AnotherPomodoro?utm_source=FocusTide&utm_medium=web&utm_content=settings"
           bg-class="bg-[#1da1f2]"
           inner-class="!p-4 text-slate-50"
         >

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,13 @@
 # Domain redirects
 [[redirects]]
   from = "http://another-pomodoro.netlify.app/*"
-  to = "https://another-pomodoro.app/:splat"
+  to = "https://focustide.app/:splat"
   status = 301
   force = true
 
 [[redirects]]
   from = "https://another-pomodoro.netlify.app/*"
-  to = "https://another-pomodoro.app/:splat"
+  to = "https://focustide.app/:splat"
   status = 301
   force = true
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -55,7 +55,7 @@ export default defineNuxtConfig({
     public: {
       PACKAGE_VERSION: version,
       PLATFORM: AppPlatform.web,
-      URL: 'https://another-pomodoro.app'
+      URL: 'https://focustide.app'
     }
   },
 


### PR DESCRIPTION
This PR edits the Netlify config and some URL's to point to the app's new domain (https://focustide.app).