### PR TITLE
fix(todo): To-do panel stays full width until md breakpoint

### DIFF
--- a/layouts/timer.vue
+++ b/layouts/timer.vue
@@ -29,7 +29,7 @@ useHead(() => {
       <SettingsPanel v-show="openPanels.settings" class="right-0" />
     </transition>
     <transition enter-from-class="translate-y-full" enter-active-class="duration-300 ease-out" leave-to-class="translate-y-full" leave-active-class="duration-150 ease-in">
-      <TodoList v-if="settingsStore.tasks.enabled && openPanels.todo" class="fixed bottom-0 z-10 w-full max-w-lg transition-all rounded-t-xl xl:right-4 xl:pb-8" :editing="[0].includes(scheduleStore.timerState)" @hide="openPanels.todo = false" />
+      <TodoList v-if="settingsStore.tasks.enabled && openPanels.todo" class="fixed bottom-0 z-10 w-full md:max-w-lg transition-all rounded-t-xl md:right-4 md:pb-8" :editing="[0].includes(scheduleStore.timerState)" @hide="openPanels.todo = false" />
     </transition>
     <slot />
   </div>


### PR DESCRIPTION
This PR adjusts the to-do panel so it stays full-width until hitting the `md` breakpoint.