### PR TITLE
fix: Redirect another-pomodoro.app to focustide.app

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,18 @@
   force = true
 
 [[redirects]]
+  from = "http://another-pomodoro.app/*"
+  to = "https://focustide.app/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "https://another-pomodoro.app/*"
+  to = "https://focustide.app/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/timer"
   to = "/"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -39,18 +39,3 @@
   from = "/_hive/*"
   to = "https://hive.splitbee.io/:splat"
   status = 200
-
-[[redirects]]
-  from = "/fa.js"
-  to = "https://fairdatacenter.de/cdn/fair.js"
-  status = 200
-
-[[redirects]]
-  from = "/pa.js"
-  to = "https://plausible.io/js/plausible.outbound-links.js"
-  status = 200
-
-[[redirects]]
-  from = "/plausible-api"
-  to = "https://plausible.io/api/event"
-  status = 202


### PR DESCRIPTION
This PR adds new redirect entries to the `netlify.toml` configuration file to explicitly redirect `another-pomodoro.app` to `focustide.app`. It also removes some unnecessary proxy redirects.