### PR TITLE
fix(meta): Use metadata again on the site

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -41,11 +41,6 @@ const iconSvg = computed(() => `data:image/svg+xml,
 
 definePageMeta({ layout: 'timer', layoutTransition: false })
 useHead({
-  meta: [{
-    hid: 'description',
-    name: 'description',
-    content: 'Jumpstart your productivity sessions with FocusTide. Start your timer session on this page, or check the home page for a guided tour!'
-  }],
   link: [
     {
       rel: 'icon',


### PR DESCRIPTION
This PR fixes the fact that additional metadata was not registered on the site when it was upgraded to Nuxt 3.