### PR TITLE
fix: App opens in the user's language on first launch

### DIFF
--- a/plugins/i18n.ts
+++ b/plugins/i18n.ts
@@ -2,6 +2,8 @@ import { createI18n } from 'vue-i18n'
 import { PiniaPluginContext } from 'pinia'
 
 import messages from '@intlify/unplugin-vue-i18n/messages'
+import { nextTick } from 'vue'
+import { useSettings } from '~~/stores/settings'
 
 interface Language {
   /// The name of the language written in that language (eg. "magyar" for Hungarian)
@@ -43,6 +45,24 @@ export const languages : LanguageStore = {
     name: 'Português (Brasil)',
     iso: 'pt-BR'
   }
+}
+
+const getAppLocale = (inputLocaleString : string) : string => {
+  // match ISO first
+  const matchingIsoCodes = Object.keys(languages).filter(key => languages[key].iso.toLowerCase() === inputLocaleString.toLowerCase())
+
+  if (matchingIsoCodes.length > 0) {
+    return matchingIsoCodes[0]
+  }
+
+  // then match on language keys
+  const looselyMatchingLanguages = Object.keys(languages).filter(key => inputLocaleString.toLowerCase().startsWith(key))
+  if (looselyMatchingLanguages.length > 0) {
+    return looselyMatchingLanguages[0]
+  }
+
+  // default to English
+  return 'en'
 }
 
 export default defineNuxtPlugin(({ vueApp, $pinia }) => {
@@ -95,6 +115,13 @@ export default defineNuxtPlugin(({ vueApp, $pinia }) => {
   }
 
   installPiniaI18nPlugin()
+
+  // update locale setting based on browser language
+  nextTick(() => {
+    useSettings().lang = getAppLocale(
+      typeof navigator !== 'undefined' ? navigator.language : 'en'
+    )
+  })
 
   return {
     provide: {

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -22,7 +22,7 @@ export enum Section {
 
 export interface Settings {
   _updated: boolean,
-  lang: string,
+  lang?: string,
   visuals: {
     theme: {
       work: number[],
@@ -99,19 +99,10 @@ export const AvailableSoundSets = {
   SOUNDSET_MUSICAL: 'musical'
 }
 
-const getDefaultLocale = () : string => {
-  if (process.server || !window || !window.navigator || !window.navigator.language) {
-    return 'en'
-  }
-
-  const consideredLanguages = Object.keys(languages).filter(lang => window.navigator.language.split('-')[0].includes(lang))
-  return consideredLanguages.length > 0 ? consideredLanguages[0] : 'en'
-}
-
 export const useSettings = defineStore('settings', {
   state: () : Settings => ({
     _updated: false,
-    lang: getDefaultLocale(),
+    lang: undefined,
     visuals: {
       theme: {
         work: [255, 107, 107],
@@ -177,6 +168,10 @@ export const useSettings = defineStore('settings', {
   }),
 
   getters: {
+    getCurrentLocale: (state) => {
+      return state.lang ?? 'en'
+    },
+
     getActiveSchedulePreset: (state) => {
       const index = Object.entries(timerPresets).findIndex(([_key, value]) => {
         return JSON.stringify(value.lengths) === JSON.stringify(state.schedule.lengths)


### PR DESCRIPTION
The app now correctly opens in the user's language on first launch (if there were no persisted language settings). The app first tries to match the ISO code entirely, then tries to find a loose match (e.g. resolving to `fr` for `fr-BE`).