### PR TITLE
feat: Allow theming section colours

### DIFF
--- a/components/base/inputNumber.vue
+++ b/components/base/inputNumber.vue
@@ -11,6 +11,18 @@ const props = defineProps({
   max: {
     type: Number,
     default: Infinity
+  },
+  prefix: {
+    type: String,
+    default: ''
+  },
+  postfix: {
+    type: String,
+    default: ''
+  },
+  valueClass: {
+    type: String,
+    default: ''
   }
 })
 
@@ -42,14 +54,14 @@ const updateInput = (newValue: string) => {
 <template>
   <div class="flex flex-row items-center gap-2">
     <input
-      class="relative h-3 min-w-0 bg-transparent appearance-none group isolate"
+      class="relative h-3 min-w-0 bg-transparent appearance-none group isolate w-full"
       :value="state.value"
       :min="props.min"
       :max="props.max"
       type="range"
       @input="(e) => updateInput((e.target as HTMLInputElement).value)"
     >
-    <span class="min-w-[2ch] text-center" v-text="state.value" />
+    <span class="min-w-[2ch] text-center" :class="props.valueClass" v-text="`${props.prefix}${state.value}${props.postfix}`" />
   </div>
 </template>
 

--- a/components/base/uiOption.vue
+++ b/components/base/uiOption.vue
@@ -26,6 +26,7 @@ const emit = defineEmits<{(type: 'click'): void}>()
     }]"
     @click="emit('click')"
   >
+    <slot name="pre" />
     <div class="text-lg" :class="[{'font-bold uppercase': props.description.length > 0 }]">
       <slot name="title">
         {{ props.title }}
@@ -36,5 +37,6 @@ const emit = defineEmits<{(type: 'click'): void}>()
         {{ props.description }}
       </slot>
     </div>
+    <slot name="post" />
   </button>
 </template>

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -145,7 +145,6 @@ notificationsStore.updateEnabled()
           <div v-else-if="state.activeTab === 3" :key="3" class="settings-tab">
             <SettingsItem :type="Control.Empty" path="visuals.theme" />
             <ThemeSettings />
-            <Divider />
             <SettingsItem :type="Control.Check" path="visuals.darkMode" />
             <Divider />
             <SettingsItem :type="Control.Option" path="currentTimer" :choices="{traditional: 'traditional', approximate: 'approximate', percentage: 'percentage'}" />

--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -2,6 +2,7 @@
 import { XIcon as CloseIcon, AdjustmentsIcon as TabIconGeneral, AlarmIcon as TabIconSchedule, ArtboardIcon as TabIconVisuals, InfoCircleIcon as InfoIcon, InfoCircleIcon as TabIconAbout } from 'vue-tabler-icons'
 
 import { ButtonImportance } from '../base/types/button'
+import ThemeSettings from './theme/themeSettings.vue'
 import OptionGroup from '@/components/base/optionGroup.vue'
 import TabHeader from '@/components/settings/panel/tabHeader.vue'
 import ExportButton from '@/components/settings/exportButton.vue'
@@ -142,6 +143,9 @@ notificationsStore.updateEnabled()
 
           <!-- Display -->
           <div v-else-if="state.activeTab === 3" :key="3" class="settings-tab">
+            <SettingsItem :type="Control.Empty" path="visuals.theme" />
+            <ThemeSettings />
+            <Divider />
             <SettingsItem :type="Control.Check" path="visuals.darkMode" />
             <Divider />
             <SettingsItem :type="Control.Option" path="currentTimer" :choices="{traditional: 'traditional', approximate: 'approximate', percentage: 'percentage'}" />

--- a/components/settings/theme/colorChanger.vue
+++ b/components/settings/theme/colorChanger.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { HSLToRGB, RGBToHSL } from './colorUtils'
+import InputNumber from '~~/components/base/inputNumber.vue'
+
+interface InputProps {
+  inputTheme: number[]
+}
+
+const props = defineProps<InputProps>()
+
+const propHSL = RGBToHSL(props.inputTheme[0], props.inputTheme[1], props.inputTheme[2])
+const inputHue = ref(propHSL[0] ?? 0)
+const inputSat = ref(propHSL[1] ?? 10)
+const inputLit = ref(60)
+
+const previewColorRGB = computed(() => HSLToRGB(inputHue.value, inputSat.value, inputLit.value))
+
+const emit = defineEmits<{(e: 'input', rgbColors: number[]) : void }>()
+
+watch(previewColorRGB, (newRGB) => {
+  emit('input', newRGB)
+})
+
+watch(() => props.inputTheme, (newTheme) => {
+  const themeHSL = RGBToHSL(newTheme[0], newTheme[1], newTheme[2])
+
+  inputHue.value = themeHSL[0]
+  inputSat.value = themeHSL[1]
+})
+</script>
+
+<template>
+  <div class="flex flex-row gap-4">
+    <div class="w-6 h-6 rounded-full flex-shrink-0" :style="{ backgroundColor: `rgb(${previewColorRGB[0]} ${previewColorRGB[1]} ${previewColorRGB[2]})` }" />
+    <InputNumber
+      class="flex-grow"
+      value-class="w-[4ch]"
+      postfix="°"
+      :value="inputHue"
+      :min="0"
+      :max="360"
+      @input="$value => inputHue = $value"
+    />
+    <InputNumber
+      class="flex-grow"
+      value-class="w-[4ch]"
+      :value="inputSat"
+      postfix="%"
+      :min="10"
+      :max="100"
+      @input="$value => inputSat = $value"
+    />
+    <!-- <InputNumber
+      class="flex-grow"
+      value-class="w-[4ch]"
+      :value="inputLit"
+      :min="50"
+      :max="80"
+      @input="$value => inputLit = $value"
+    /> -->
+  </div>
+</template>

--- a/components/settings/theme/colorUtils.ts
+++ b/components/settings/theme/colorUtils.ts
@@ -1,0 +1,39 @@
+/**
+ *  Convert HSL values to an RGB array (rounded)
+ * @see https://www.30secondsofcode.org/js/s/hsl-to-rgb
+ */
+const HSLToRGB = (h: number, s: number, l: number) => {
+  s /= 100
+  l /= 100
+  const k = (n: number) => (n + h / 30) % 12
+  const a = s * Math.min(l, 1 - l)
+  const f = (n: number) =>
+    l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)))
+  return [Math.round(255 * f(0)), Math.round(255 * f(8)), Math.round(255 * f(4))]
+}
+
+/**
+ *  Convert RGB values to an HSL array (rounded)
+ * @see https://www.30secondsofcode.org/js/s/rgb-to-hsl
+ */
+const RGBToHSL = (r: number, g: number, b: number) => {
+  r /= 255
+  g /= 255
+  b /= 255
+  const l = Math.max(r, g, b)
+  const s = l - Math.min(r, g, b)
+  const h = s
+    ? l === r
+      ? (g - b) / s
+      : l === g
+        ? 2 + (b - r) / s
+        : 4 + (r - g) / s
+    : 0
+  return [
+    Math.round(60 * h < 0 ? 60 * h + 360 : 60 * h),
+    Math.round(100 * (s ? (l <= 0.5 ? s / (2 * l - s) : s / (2 - (2 * l - s))) : 0)),
+    Math.round((100 * (2 * l - s)) / 2)
+  ]
+}
+
+export { RGBToHSL, HSLToRGB }

--- a/components/settings/theme/prebuiltThemes.ts
+++ b/components/settings/theme/prebuiltThemes.ts
@@ -1,0 +1,27 @@
+export const prebuiltThemes = {
+  default: {
+    work: [255, 107, 107],
+    shortpause: [244, 162, 97],
+    longpause: [46, 196, 182]
+  },
+  blue0: {
+    work: [67, 111, 250],
+    shortpause: [250, 126, 92],
+    longpause: [111, 173, 38]
+  },
+  brightcompl: {
+    work: [250, 104, 90],
+    shortpause: [125, 250, 102],
+    longpause: [77, 248, 250]
+  },
+  seasons: {
+    work: [129, 217, 82],
+    shortpause: [192, 240, 79],
+    longpause: [230, 227, 76]
+  },
+  brewerset2: {
+    work: [102, 194, 165],
+    shortpause: [252, 141, 98],
+    longpause: [141, 160, 203]
+  }
+}

--- a/components/settings/theme/themePreview.vue
+++ b/components/settings/theme/themePreview.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+interface ThemePreviewProps {
+  theme: {
+    work: number[]
+    shortpause: number[]
+    longpause: number[]
+  }
+}
+
+const props = defineProps<ThemePreviewProps>()
+
+const colorArrayToRgb = (color: number[]) => `rgb(${color.join(', ')})`
+</script>
+
+<template>
+  <div class="flex flex-row gap-0 isolate">
+    <div class="rounded-full w-8 h-8 z-20" :style="{ backgroundColor: colorArrayToRgb(props.theme.work) }" />
+    <div class="rounded-full w-8 h-8 -ml-2 z-10" :style="{ backgroundColor: colorArrayToRgb(props.theme.shortpause) }" />
+    <div class="rounded-full w-8 h-8 -ml-2" :style="{ backgroundColor: colorArrayToRgb(props.theme.longpause) }" />
+  </div>
+</template>

--- a/components/settings/theme/themeSettings.vue
+++ b/components/settings/theme/themeSettings.vue
@@ -42,7 +42,7 @@ const isUsingCustomTheme = ref(activeThemeKey === undefined)
           <ThemePreview class="mx-auto" :theme="theme" />
         </template>
       </UiOption>
-      <UiOption key="custom" title="Custom" class="text-center" :active="isUsingCustomTheme" @click="isUsingCustomTheme = true">
+      <UiOption key="custom" :title="$t('settings.values.visuals.theme.custom')" class="text-center" :active="isUsingCustomTheme" @click="isUsingCustomTheme = true">
         <!-- <template #pre>
           <ThemePreview class="mx-auto mb-2" :theme="customTheme" />
         </template> -->

--- a/components/settings/theme/themeSettings.vue
+++ b/components/settings/theme/themeSettings.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { prebuiltThemes } from './prebuiltThemes'
+import ColorChanger from './colorChanger.vue'
+import ThemePreview from './themePreview.vue'
+import { useSettings } from '~~/stores/settings'
+import UiOption from '~~/components/base/uiOption.vue'
+
+const settingsStore = useSettings()
+
+const customTheme = reactive(settingsStore.visuals.theme)
+const activeThemeKey = computed(() => {
+  const findValue = Object.keys(prebuiltThemes).find((key) => {
+    const rgbValues = [customTheme.work, customTheme.shortpause, customTheme.longpause].flat()
+    const prebuiltValues = [prebuiltThemes[key as keyof typeof prebuiltThemes].work, prebuiltThemes[key as keyof typeof prebuiltThemes].shortpause, prebuiltThemes[key as keyof typeof prebuiltThemes].longpause].flat()
+
+    return rgbValues.every((value, index) => prebuiltValues[index] === value)
+  })
+
+  return findValue
+})
+
+const isUsingCustomTheme = ref(activeThemeKey === undefined)
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <div class="grid grid-flow-row grid-cols-3 gap-2 mb-2">
+      <UiOption
+        v-for="(theme, index) in prebuiltThemes"
+        :key="`theme-${index}`"
+        :title="''"
+        class="text-center"
+        :active="!isUsingCustomTheme && activeThemeKey === index"
+        @click="$newTheme => {
+          settingsStore.visuals.theme.work = theme.work
+          settingsStore.visuals.theme.shortpause = theme.shortpause
+          settingsStore.visuals.theme.longpause = theme.longpause
+          isUsingCustomTheme = false
+        }"
+      >
+        <template #pre>
+          <ThemePreview class="mx-auto" :theme="theme" />
+        </template>
+      </UiOption>
+      <UiOption key="custom" title="Custom" class="text-center" :active="isUsingCustomTheme" @click="isUsingCustomTheme = true">
+        <!-- <template #pre>
+          <ThemePreview class="mx-auto mb-2" :theme="customTheme" />
+        </template> -->
+      </UiOption>
+    </div>
+
+    <template v-if="isUsingCustomTheme">
+      <ColorChanger :input-theme="customTheme.work" @input="$newColor => customTheme.work = $newColor" />
+      <ColorChanger :input-theme="customTheme.shortpause" @input="$newColor => customTheme.shortpause = $newColor" />
+      <ColorChanger :input-theme="customTheme.longpause" @input="$newColor => customTheme.longpause = $newColor" />
+    </template>
+  </div>
+</template>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -214,7 +214,8 @@
       "visuals": {
         "theme": {
           "_title": "Theme settings",
-          "_description": "Choose a set of predefined section colors or set your own"
+          "_description": "Choose a set of predefined section colors or set your own",
+          "custom": "Custom"
         },
         "darkMode": {
           "_title": "Enable dark mode",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -212,6 +212,10 @@
         }
       },
       "visuals": {
+        "theme": {
+          "_title": "Theme settings",
+          "_description": "Choose a set of predefined section colors or set your own"
+        },
         "darkMode": {
           "_title": "Enable dark mode",
           "_description": "Less bright, just as productive"


### PR DESCRIPTION
Section colours (work, pause and long pause) can now be themed! The app now includes 5 prebuilt themes and the ability to set custom colours in the HSL colour space _with some restrictions_: saturation is limited between 10-100% and lightness is currently fixed at 60%. The restrictions are there so that (1) the controls are simplified (only 2 sliders per colour) and (2) the themes cannot be "broken" (i.e. it is more difficult to create a theme that provides bad contrast).

The included themes are (from left to right, top to bottom):

* default
* blue0: blue + complementary colours
* brightcompl: bright red + complementary colours
* seasons: green + analogous colours
* brewerset2: the _colourblind-safe_ "3-class Set2" theme from [ColorBrewer2](https://colorbrewer2.org/#type=qualitative&scheme=Set2&n=3)

No RGB settings for now (sorry!). If you have theme suggestions (those can be full RGB themes), let me know!

Note that section themes also do not affect the UI theme, it remains red.

![The new theme settings](https://user-images.githubusercontent.com/18259108/222897656-54b011a8-2671-4a90-904e-d9474c8342c7.png)
