### PR TITLE
fix: Adjust viewport height to eliminate scrolling on mobile

### DIFF
--- a/layouts/timer.vue
+++ b/layouts/timer.vue
@@ -20,7 +20,7 @@ useHead(() => {
 </script>
 
 <template>
-  <div class="relative w-screen h-screen">
+  <div class="relative w-full h-full">
     <transition enter-from-class="opacity-0" enter-active-class="transition duration-300" leave-to-class="opacity-0" leave-active-class="transition">
       <!-- Darkening overlay -->
       <div v-show="openPanels.settings" class="fixed z-40 w-screen h-screen bg-black bg-opacity-40" />
@@ -34,3 +34,9 @@ useHead(() => {
     <slot />
   </div>
 </template>
+
+<style>
+html, body, #__nuxt {
+  height: 100%;
+}
+</style>

--- a/layouts/timer.vue
+++ b/layouts/timer.vue
@@ -36,6 +36,7 @@ useHead(() => {
 </template>
 
 <style>
+/* stylelint-disable-next-line selector-id-pattern */
 html, body, #__nuxt {
   height: 100%;
 }


### PR DESCRIPTION
This PR adjusts page height to 100% (instead of `100vh`) so users won't need to overscroll on mobile to see the whole page.