### PR TITLE
fix: Add missing query param to https redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,7 +19,7 @@
 
 [[redirects]]
   from = "https://another-pomodoro.app/*"
-  to = "https://focustide.app/:splat"
+  to = "https://focustide.app/:splat?olddomain"
   status = 301
   force = true
 


### PR DESCRIPTION
This PR simply adds the `?olddomain` query param to HTTPS redirects, which caused the warning about using the old domain to not appear.