### PR TITLE
feat(timer): Allow choosing a behavior when a section ends

### DIFF
--- a/components/settings/settingsPanel.vue
+++ b/components/settings/settingsPanel.vue
@@ -69,6 +69,7 @@ notificationsStore.updateEnabled()
             <Divider />
             <SettingsItem :type="Control.Check" path="adaptiveTicking.enabled" />
             <SettingsItem v-if="isWeb" :type="Control.Check" path="timerControls.enableKeyboardShortcuts" />
+            <SettingsItem :type="Control.Option" path="sectionEndAction" :choices="{continue: 'continue', stop: 'stop', skip: 'skip'}" />
 
             <template v-if="isWeb">
               <Divider />

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -107,6 +107,20 @@
           "_description": "Timer will tick less frequently while in the background"
         }
       },
+      "sectionEndAction": {
+        "_title": "Section end behavior",
+        "_description": "What should happen when the timer runs out",
+        "_values": {
+          "continue": "Continue",
+          "stop": "Stop",
+          "skip": "Advance"
+        },
+        "_valueDescription": {
+          "continue": "Keep ticking",
+          "stop": "Stop the timer",
+          "skip": "Start the next section"
+        }
+      },
       "schedule": {
         "longPauseInterval": {
           "_title": "Long Break interval",

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -2,12 +2,20 @@ import { defineStore } from 'pinia'
 import { EventType, useEvents } from './events'
 import TickMultipliers from '~~/assets/settings/adaptiveTickingMultipliers'
 import timerPresets from '~~/assets/settings/timerPresets'
-import { languages } from '~~/plugins/i18n'
 
 export enum TimerType {
   Traditional = 'traditional',
   Approximate = 'approximate',
   Percentage = 'percentage'
+}
+
+export enum SectionEndAction {
+  /** Continue ticking after the section ended */
+  KeepTicking = 'continue',
+  /** Stop the timer after the section ended, displaying a checkmark */
+  Stop = 'stop',
+  /** Automatically start the next section as soon as the previous one ended */
+  Skip = 'skip'
 }
 
 export enum SoundSet {
@@ -53,6 +61,7 @@ export interface Settings {
     },
     eventLoggingEnabled: boolean,
     currentTimer: TimerType,
+    sectionEndAction: SectionEndAction,
     adaptiveTicking: {
       enabled: boolean,
       baseTickRate: number,
@@ -132,6 +141,7 @@ export const useSettings = defineStore('settings', {
       }
     },
     eventLoggingEnabled: false,
+    sectionEndAction: SectionEndAction.Skip,
     currentTimer: TimerType.Approximate,
     adaptiveTicking: {
       enabled: true,


### PR DESCRIPTION
This PR enables the user to choose from three behaviors when a section ends:

* continue ticking (this was the default behavior since version 1.2)
* stop (the timer will stay completed until the user starts the next section)
* skip (keeps the timer running but automatically advances to the next section)

The new setting is on the "Main" page of the settings menu.