### PR TITLE
fix(ticker): Fix wrong sound playing on auto-advance

### DIFF
--- a/components/ticker.ts
+++ b/components/ticker.ts
@@ -153,10 +153,13 @@ export function useTicker () {
     if (nextState === TimerState.RUNNING && isTimerJustFinished) {
       // timer completed, notify participants
       eventsStore.recordEvent(EventType.TIMER_FINISH)
+
       if (settingsStore.sectionEndAction === SectionEndAction.Stop) {
         scheduleStore.timerState = TimerState.COMPLETED
       } else if (settingsStore.sectionEndAction === SectionEndAction.Skip) {
-        scheduleStore.advance()
+        nextTick(() => {
+          scheduleStore.advance()
+        })
       }
     }
   }


### PR DESCRIPTION
When auto-advancing was re-implemented in #361, the app started playing the wrong sound when the section automatically advanced. This was caused by Vue handling the section advance the following way:

1. The `events` store receives the `TIMER_FINISH` event (-> there is a watcher in the `web` component that plays the next section's sound based on this event)
2. The `schedule` store gets the call to advance the current section
3. The watcher plays the sound of the next section (but by this time, the schedule has already advanced, so it will play the second next section's sound)

This is fixed by wrapping the `advance()` call in a `nextTick`, so the correct sound will start playing in the current tick, and only then will the schedule advance.