### PR TITLE
chore: Update FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-custom: ['https://www.buymeacoffee.com/imreg']
+buy_me_a_coffee: imreg


### PR DESCRIPTION
Since [GitHub Sponsors now supports Buy Me a Coffee](https://github.blog/changelog/2024-03-14-sponsors-now-supports-polar-and-buy-me-a-coffee-as-funding-platform-options/), the support file is updated to use the new way to refer to the Buy Me a Coffee page.