### PR TITLE
fix(appBar): Add explicit size to tasks icon

### DIFF
--- a/components/appBar.vue
+++ b/components/appBar.vue
@@ -33,7 +33,7 @@ const settingsStore = useSettings()
       :aria-label="$t('appbar.todo')"
       @click="openPanels.todo = !openPanels.todo"
     >
-      <IconChecklist class="inline-block" />
+      <IconChecklist size="24" class="inline-block" />
     </CButton>
     <CButton
       circle


### PR DESCRIPTION
This should be a tiny fix, hopefully no more icons are left without explicit sizing.