### PR TITLE
fix: Add back dark mode handling

### DIFF
--- a/layouts/timer.vue
+++ b/layouts/timer.vue
@@ -14,7 +14,10 @@ const { locale } = useI18n()
 
 useHead(() => {
   return {
-    htmlAttrs: { lang: locale }
+    htmlAttrs: { lang: locale },
+    bodyAttrs: {
+      class: computed(() => settingsStore.visuals.darkMode ? 'dark' : '')
+    }
   }
 })
 </script>


### PR DESCRIPTION
This PR makes the `timer` layout dynamically add the `dark` class to the `<body>` tag when the relevant setting is enabled. During the update, dark mode entirely broke, and previously it needed a page refresh to clear out, now it should be properly reactive again.