### PR TITLE
refactor(icon_resize): Refactor icon generator to execute in a single run

### DIFF
--- a/modules/build/icon_resize.ts
+++ b/modules/build/icon_resize.ts
@@ -3,15 +3,15 @@ import { join } from 'node:path'
 import { existsSync, mkdirSync } from 'fs'
 import sharp from 'sharp'
 
-interface IconVariant {
-    src: string,
-    prefix: string,
+export interface IconVariant {
+    src: string
+    prefix: string
     purpose: string
+    size: number[]
     bgColor?: string
   }
   
-interface IconResizerPluginOptions {
-    sizes: number[],
+export interface IconResizerPluginOptions {
     outputFolder: string,
     variants: IconVariant[],
   }
@@ -31,10 +31,10 @@ export default defineNuxtModule({
                     mkdirSync(outputFolder, { recursive: true })
                 }
 
-                console.info(`Generating ${iconConfig.src} into sizes [${moduleOptions.sizes.join(', ')}] -> ${moduleOptions.outputFolder}`)
+                console.info(`Generating ${iconConfig.src} into sizes [${iconConfig.size.join(', ')}] -> ${moduleOptions.outputFolder}`)
 
                 const promises = []
-                for (const size of moduleOptions.sizes) {
+                for (const size of iconConfig.size) {
                     const outputFileName = `${iconConfig.prefix}${size}.png`
                     let basePromise = sharp(join(nuxt.options.rootDir, iconConfig.src)).resize(size)
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,28 +7,38 @@ import { fileURLToPath } from 'url'
 import VueI18nVitePlugin from '@intlify/unplugin-vue-i18n/vite'
 import StylelintPlugin from 'vite-plugin-stylelint'
 import { AppPlatform } from './platforms/platforms'
+import type { IconResizerPluginOptions } from './modules/build/icon_resize'
 
 const packageJson = fs.readFileSync('./package.json').toString()
 const version = JSON.parse(packageJson).version || 0
 
-const iconConfig = {
+const iconConfig: IconResizerPluginOptions = {
   outputFolder: 'icons',
-  sizes: [64, 120, 144, 152, 192, 384, 512],
   variants: [
     {
       src: '/public/icon.png',
       prefix: 'icon-maskable-',
-      purpose: 'maskable'
+      purpose: 'maskable',
+      size: [64, 120, 144, 152, 192, 384, 512],
     },
     {
       src: '/public/icon_monochrome.png',
       prefix: 'icon-monochrome-',
-      purpose: 'monochrome'
+      purpose: 'monochrome',
+      size: [64, 120, 144, 152, 192, 384, 512],
     },
     {
       src: '/public/favicon.png',
       prefix: 'icon-base-',
-      purpose: 'any'
+      purpose: 'any',
+      size: [64, 120, 144, 152, 192, 384, 512],
+    },
+    {
+      src: '/public/icon.png',
+      prefix: 'icon-apple-',
+      purpose: 'any',
+      bgColor: '#fee2e2',
+      size: [192]
     }
   ]
 }
@@ -115,18 +125,6 @@ export default defineNuxtConfig({
     // Doc: https://github.com/nuxt-community/stylelint-module
     '@pinia/nuxt',
     ['./modules/build/icon_resize', iconConfig],
-    ['./modules/build/icon_resize', {
-      outputFolder: 'icons',
-      sizes: [192],
-      variants: [
-        {
-          src: '/public/icon.png',
-          prefix: 'icon-apple-',
-          purpose: 'any',
-          bgColor: '#fee2e2'
-        }
-      ]
-    }],
     ['modules/build/pwa', { swPath: 'serviceworker.js' }]
     // '@nuxtjs/sitemap'
   ],


### PR DESCRIPTION
This PR refactors  the `icon_resize` module so that it can accept different `size` parameters for each icon to generate. This makes it possible to generate all icons with a single inclusion of the module.

Fixes #376